### PR TITLE
JSON tmLanguage highlighter does not recognize '-' in include identifiers

### DIFF
--- a/Support/Sublime JSON Syntax Definition.JSON-tmLanguage
+++ b/Support/Sublime JSON Syntax Definition.JSON-tmLanguage
@@ -34,7 +34,7 @@
       },
 
       "include": {
-        "match": "\"(include)\"\\s*?:\\s*?\"(?:(#)(\\w+)|(\\$)(self)|([A-Za-z0-9.]+))\"",
+        "match": "\"(include)\"\\s*?:\\s*?\"(?:(#)([a-zA-Z0-9_-]+)|(\\$)(self)|([A-Za-z0-9.]+))\"",
         "captures": {
           "1": { "name": "keyword.other.control.json-tmlanguage" },
           "2": { "name": "keyword.other.variable.mark.json-tmlanguage" },

--- a/Support/Sublime JSON Syntax Definition.tmLanguage
+++ b/Support/Sublime JSON Syntax Definition.tmLanguage
@@ -171,7 +171,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>"(include)"\s*?:\s*?"(?:(#)(\w+)|(\$)(self)|([A-Za-z0-9.]+))"</string>
+			<string>"(include)"\s*?:\s*?"(?:(#)([a-zA-Z0-9_-]+)|(\$)(self)|([A-Za-z0-9.]+))"</string>
 		</dict>
 		<key>match</key>
 		<dict>


### PR DESCRIPTION
many TextMate grammars actually use dash as a separator in pattern names, and they're even allowed
in [`repositoryItem`](https://github.com/SublimeText/AAAPackageDev/blob/39bca6fdfe/Support/Sublime%20JSON%20Syntax%20Definition.JSON-tmLanguage#L142)
