### PR TITLE
Plugin shouldn't crash when a scratch view is active

### DIFF
--- a/package_dev.py
+++ b/package_dev.py
@@ -127,7 +127,7 @@ class PackageManager(object):
 
 class PlistToJson(sublime_plugin.TextCommand):
     def is_enabled(self ):
-        return self.view.file_name().endswith('.tmLanguage')
+        return self.view.file_name() and self.view.file_name().endswith('.tmLanguage')
         
     def run(self, edit):
         plist_data = plistlib.readPlist(self.view.file_name())

--- a/syntax_def_dev.py
+++ b/syntax_def_dev.py
@@ -69,7 +69,7 @@ class JsonToPlistCommand(sublime_plugin.WindowCommand):
 
     def is_enabled(self):
         v = self.window.active_view()
-        return (v and (self.get_file_ext(v.file_name()) is not None))
+        return (v and v.file_name() and (self.get_file_ext(v.file_name()) is not None))
 
     def get_file_ext(self, file_name):
         ret = self.ext_regexp.search(file_name)
@@ -144,7 +144,7 @@ class PlistToJsonCommand(sublime_plugin.WindowCommand):
         return (self.get_file_ext(v) is not None)
 
     def get_file_ext(self, v):
-        if not v:
+        if not v or not v.file_name():
             return None
         fn = v.file_name()
         ext = os.path.splitext(fn)[1]


### PR DESCRIPTION
AAAPackageDev has been printing stacktraces to the console when i open the command palette from a scratch view.

It looks like the errors all derive from a couple is_enabled handlers not expecting view.file_name() to return None.
