### PR TITLE
allow backslash in key bindings

### DIFF
--- a/Support/Sublime Key Map.tmLanguage
+++ b/Support/Sublime Key Map.tmLanguage
@@ -90,7 +90,7 @@
 					<key>contentName</key>
 					<string>meta.key.sequence.sublimekeymap</string>
 					<key>end</key>
-					<string>(?&lt;!\\)(")</string>
+					<string>(?&lt;![^\\]\\)(")</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>
@@ -228,7 +228,7 @@
 			<key>contentName</key>
 			<string>string.double.quote.sublimekeymap</string>
 			<key>end</key>
-			<string>(?&lt;!\\)"</string>
+			<string>(?&lt;![^\\]\\)"</string>
 			<key>patterns</key>
 			<array>
 				<dict>


### PR DESCRIPTION
a key binding such as "ctrl+\\" caused the sublime key map syntax parser to report a bug. I changed the string end regex to allow for escape backslash immediately before the final doublequote.
