### PR TITLE
Fixes incorrect resolution of Lib directory when packages directory is a...

### DIFF
--- a/AAA.py
+++ b/AAA.py
@@ -3,10 +3,10 @@ import sys
 
 from sublime import packages_path
 
-PLUGIN_NAME = os.getcwdu().replace(packages_path(), '')[1:]
+BASE_PATH = os.path.abspath(os.path.dirname(__file__))
 
 # Makes sublime_lib package available for all packages.
-libpath = os.path.join(packages_path(), PLUGIN_NAME, "Lib")
+libpath = os.path.join(BASE_PATH, "Lib")
 if not libpath in sys.path:
     sys.path.append(libpath)
     print "[AAAPackageDev] Added sublime_lib to sys.path."


### PR DESCRIPTION
... symlink.

Uses the path resolution technique used in the Emmet package to correctly locate library files when the path contains symlinks.  Fixes Issue #32.
