### PR TITLE
Constant.numeric.boolean -> constant.language, added null

### DIFF
--- a/Syntax Definitions/Sublime Key Map.JSON-tmLanguage
+++ b/Syntax Definitions/Sublime Key Map.JSON-tmLanguage
@@ -117,8 +117,8 @@
       },
       "numericPrimitives": {
         "patterns": [
-          {  "name": "constant.numeric.boolean.sublimekeymap",
-             "match": "\\b(?:true|false)\\b"
+          {  "name": "constant.language.sublimekeymap",
+             "match": "\\b(?:true|false|null)\\b"
           },
           {  "name": "constant.numeric.sublimekeymap",
              "match": "\\d+(?:\\.\\d+)?"

--- a/Syntax Definitions/Sublime Key Map.tmLanguage
+++ b/Syntax Definitions/Sublime Key Map.tmLanguage
@@ -223,9 +223,9 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\b(?:true|false)\b</string>
+					<string>\b(?:true|false|null)\b</string>
 					<key>name</key>
-					<string>constant.numeric.boolean.sublimekeymap</string>
+					<string>constant.language.sublimekeymap</string>
 				</dict>
 				<dict>
 					<key>match</key>


### PR DESCRIPTION
`true`, `false`, and `null` (or their equivalents) are scoped in every language I've worked with as `constant.language`. I wanted to make that consistent here, because (1) syntax highlighting will now be consistent with JSON and other languages, and (2) I wanted to add `null`, which (to my knowledge) is not a Boolean value.