### PR TITLE
Properly color comments for *.sublime-commands

### DIFF
--- a/Syntax Definitions/Sublime Commands.JSON-tmLanguage
+++ b/Syntax Definitions/Sublime Commands.JSON-tmLanguage
@@ -5,6 +5,7 @@
   "fileTypes": ["sublime-commands"],
 
   "patterns": [
+      { "include": "#comment" },
       { "begin": "(\\[)",
         "beginCaptures": {
             "1": { "name": "punctuation.definition.collection.start.sublimecommands" }
@@ -15,6 +16,7 @@
         },
 
         "patterns": [
+            { "include": "#comment" },
             { "include": "#command" },
             { "include": "#args" },
             { "match": "(?<!\\}),",
@@ -74,6 +76,18 @@
             }
           },
           { "include": "#args" }
+        ]
+      },
+
+      "comment": {
+        "patterns": [
+          { "name": "comment.single.line.sublimecommands",
+            "match": "//.*"
+          },
+          { "name": "comment.block.sublimecommands",
+             "begin": "/\\*",
+             "end": "\\*/"
+          }
         ]
       }
   },

--- a/Syntax Definitions/Sublime Commands.tmLanguage
+++ b/Syntax Definitions/Sublime Commands.tmLanguage
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>fileTypes</key>
@@ -10,6 +10,10 @@
 	<string>Sublime Text Commands</string>
 	<key>patterns</key>
 	<array>
+		<dict>
+			<key>include</key>
+			<string>#comment</string>
+		</dict>
 		<dict>
 			<key>begin</key>
 			<string>(\[)</string>
@@ -33,6 +37,10 @@
 			</dict>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>include</key>
+					<string>#comment</string>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>#command</string>
@@ -152,6 +160,26 @@
 				<dict>
 					<key>include</key>
 					<string>#args</string>
+				</dict>
+			</array>
+		</dict>
+		<key>comment</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>//.*</string>
+					<key>name</key>
+					<string>comment.single.line.sublimecommands</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>/\*</string>
+					<key>end</key>
+					<string>\*/</string>
+					<key>name</key>
+					<string>comment.block.sublimecommands</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
The comment syntax defs are copied from `Sublime Settings.JSON-tmLanguage`.