### PR TITLE
Fix: Add MAC OS 'option' key to Sublime Key Map syntax definition.

### DIFF
--- a/Syntax Definitions/Sublime Key Map.JSON-tmLanguage
+++ b/Syntax Definitions/Sublime Key Map.JSON-tmLanguage
@@ -49,10 +49,10 @@
                        "1": { "name": "entity.other.attribute-name.key.captured.sublimekeymap" }
                    }
                 },
-                { "match": "(?<!shift|ctrl|alt|super|\\+)\\+",
+                { "match": "(?<!shift|ctrl|alt|super|option|\\+)\\+",
                   "name": "invalid.illegal.key.sequence.sublimekeymap"
                 },
-                { "match": "(shift|ctrl|alt|super)(\\+)",
+                { "match": "(shift|ctrl|alt|super|option)(\\+)",
                   "captures": {
                       "1": { "name": "support.function.modifier.key.sublimekeymap" },
                       "2": { "name": "keyword.modifier.key.connector.sublimekeymap" }

--- a/Syntax Definitions/Sublime Key Map.tmLanguage
+++ b/Syntax Definitions/Sublime Key Map.tmLanguage
@@ -123,7 +123,7 @@
 						</dict>
 						<dict>
 							<key>match</key>
-							<string>(?&lt;!shift|ctrl|alt|super|\+)\+</string>
+							<string>(?&lt;!shift|ctrl|alt|super|option|\+)\+</string>
 							<key>name</key>
 							<string>invalid.illegal.key.sequence.sublimekeymap</string>
 						</dict>
@@ -142,7 +142,7 @@
 								</dict>
 							</dict>
 							<key>match</key>
-							<string>(shift|ctrl|alt|super)(\+)</string>
+							<string>(shift|ctrl|alt|super|option)(\+)</string>
 						</dict>
 						<dict>
 							<key>match</key>


### PR DESCRIPTION
I am not an OSX user, but ST complained about 'option' key to be invalid. I guess it is not intented to be?