### PR TITLE
separate property list syntax from tmPreferences syntax

### DIFF
--- a/Package/TextMate Preferences/Completions/plist tags.sublime-completions
+++ b/Package/TextMate Preferences/Completions/plist tags.sublime-completions
@@ -1,0 +1,16 @@
+{
+	"scope": "meta.tag.xml invalid.illegal.unknown-or-unexpected-tag.plist",
+
+	"completions": [
+			"dict",
+			"key",
+			"integer",
+			"string",
+			"true",
+			"false",
+			"array",
+			"date",
+			"data",
+			"real"
+	]
+}

--- a/Package/TextMate Preferences/Completions/tmPreference keys.sublime-completions
+++ b/Package/TextMate Preferences/Completions/tmPreference keys.sublime-completions
@@ -1,0 +1,24 @@
+{
+	"scope": "meta.dict-key-unknown.textmateprefs | meta.close-unknown-dict-key-tag.textmateprefs",
+
+	"completions": [
+			"scope",
+			"decreaseIndentPattern",
+			//"batchDecreaseIndentPattern",
+			"increaseIndentPattern",
+			//"batchIncreaseIndentPattern",
+			"disableIndentNextLinePattern",
+			"bracketIndentNextLinePattern",
+			"unIndentedLinePattern",
+			"cancelCompletion",
+			"shellVariables",
+			"showInSymbolList",
+			"showInIndexedSymbolList",
+			"symbolTransformation",
+			"symbolIndexTransformation",
+			"indentParens",
+			"indentSquareBrackets",
+			"preserveIndent",
+			"icon",
+	]
+}

--- a/Package/TextMate Preferences/Plist Scope Transformation.tmPreferences
+++ b/Package/TextMate Preferences/Plist Scope Transformation.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Symbol List</string>
 	<key>scope</key>
-	<string>text.xml.plist meta.toc-list.snippet-scope.plist</string>
+	<string>meta.toc-list.scope.textmateprefs</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>

--- a/Package/TextMate Preferences/Plist ShellVariable Transformation.tmPreferences
+++ b/Package/TextMate Preferences/Plist ShellVariable Transformation.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Symbol List</string>
 	<key>scope</key>
-	<string>text.xml.plist meta.toc-list.shellVariable.name.plist</string>
+	<string>meta.toc-list.shellVariable.name.textmateprefs</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>

--- a/Package/TextMate Preferences/Property List.sublime-syntax
+++ b/Package/TextMate Preferences/Property List.sublime-syntax
@@ -2,183 +2,206 @@
 ---
 # See http://www.sublimetext.com/docs/3/syntax.html
 file_extensions:
-  - tmPreferences
   - tmTheme
+  - stTheme
 name: Property List (XML)
 scope: text.xml.plist
 contexts:
   main:
-    - match: '(?=<key>scope</key>)'
-      push:
-        - match: '(?=<string>)'
-          set: scope_string
-        - include: scope:text.xml
-    - match: '(?=<key>settings</key>)'
-      push:
-        - match: '(?=<dict>)'
-          set: settings_dict
-        - include: scope:text.xml
-    - include: scope:text.xml
-
-  scope_string:
-    - match: '(<)(string)(>)'
+    - include: xml-declarations
+    - match: '(<)(plist)\s*(?:(version)\s*(=)\s*(")(1.0)("))\s*(>)'
+      scope: meta.tag.xml
       captures:
-        1: meta.tag.xml punctuation.definition.tag.begin.xml
-        2: meta.tag.xml entity.name.tag.localname.xml
-        3: meta.tag.xml punctuation.definition.tag.end.xml
-      set: scope
-
-  scope:
-    - meta_content_scope: meta.toc-list.snippet-scope.plist
-    - match: '<!\[CDATA\['
-      scope: string.unquoted.cdata.xml punctuation.definition.string.begin.xml
+        1: punctuation.definition.tag.begin
+        2: entity.name.tag.localname.xml
+        3: entity.other.attribute-name.localname.xml
+        4: punctuation.separator.key-value.xml
+        5: string.quoted.double.xml punctuation.definition.string.begin.xml
+        6: string.quoted.double.xml
+        7: string.quoted.double.xml punctuation.definition.string.end.xml
+        8: punctuation.definition.tag.end
       push:
-        - match: ']]>'
-          scope: string.unquoted.cdata.xml punctuation.definition.string.end.xml
+        - meta_content_scope: meta.inside-plist.plist
+        - match: '(</)(plist)\s*(>)'
+          scope: meta.tag.xml
+          captures:
+            1: punctuation.definition.tag.begin.xml
+            2: entity.name.tag.localname.xml
+            3: punctuation.definition.tag.end.xml
+          set: whitespace-or-tag
+        - match: '(?=\S)(?!<!--)'
+          push:
+            - include: any-known-element
+        - include: scope:text.xml
+    - include: whitespace-or-tag
+  xml-declarations:
+    - match: '^(?=<\?|<!)'
+      push:
+        - match: $
           pop: true
-        - include: scope:text.scope-selector
-    - match: '(?=</string>)'
+        - include: scope:text.xml
+  unknown-tag:
+    - meta_scope: meta.tag.xml
+    - meta_content_scope: invalid.illegal.unknown-or-unexpected-tag.plist
+    - match: '>'
+      scope: punctuation.definition.tag.end.xml
       pop: true
-    - include: scope:text.xml#entity
-    - include: scope:text.xml#should-be-entity
-    - include: scope:text.scope-selector
-
-  settings_dict:
-    - match: '(<)(key)(>)(decreaseIndentPattern|batchDecreaseIndentPattern|increaseIndentPattern|batchIncreaseIndentPattern|disableIndentNextLinePattern|bracketIndentNextLinePattern|unIndentedLinePattern|cancelCompletion)(</)(key)(>)'
+  number:
+    - match: '(<)(integer)\s*(>)'
+      scope: meta.tag.xml
       captures:
-        1: meta.tag.xml punctuation.definition.tag.begin.xml
-        2: meta.tag.xml entity.name.tag.localname.xml
-        3: meta.tag.xml punctuation.definition.tag.end.xml
-        4: meta.toc-list.regex.plist
-        5: meta.tag.xml punctuation.definition.tag.begin.xml
-        6: meta.tag.xml entity.name.tag.localname.xml
-        7: meta.tag.xml punctuation.definition.tag.end.xml
-      push:
-        - match: '(?=<string>)'
-          set: regex_string
-        - include: scope:text.xml
-    - match: '(<)(key)(>)(shellVariables)(</)(key)(>)'
-      captures:
-        1: meta.tag.xml punctuation.definition.tag.begin.xml
-        2: meta.tag.xml entity.name.tag.localname.xml
-        3: meta.tag.xml punctuation.definition.tag.end.xml
-        4: meta.toc-list.shellVariables.plist
-        5: meta.tag.xml punctuation.definition.tag.begin.xml
-        6: meta.tag.xml entity.name.tag.localname.xml
-        7: meta.tag.xml punctuation.definition.tag.end.xml
-      push:
-        - match: '(?=<key>name</key>)'
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set:
+        - meta_content_scope: meta.inside-integer.plist
+        - match: '[^\s\d<]+'
+          scope: invalid.illegal.expected-integer.plist
+        - match: '\d+'
+          scope: constant.numeric.plist
           push:
-            - match: '(<)(string)(>)([^<]+)(</)(string)(>)'
-              captures:
-                1: meta.tag.xml punctuation.definition.tag.begin.xml
-                2: meta.tag.xml entity.name.tag.localname.xml
-                3: meta.tag.xml punctuation.definition.tag.end.xml
-                4: meta.toc-list.shellVariable.name.plist
-                5: meta.tag.xml punctuation.definition.tag.begin.xml
-                6: meta.tag.xml entity.name.tag.localname.xml
-                7: meta.tag.xml punctuation.definition.tag.end.xml
+            - match: '[^\s<]+'
+              scope: invalid.illegal.unexpected-text.plist
+            - match: '(?=<)'
               pop: true
-            - include: scope:text.xml
-        - match: '(?=</array>)'
-          pop: true
-        - include: scope:text.xml
-    - match: '(<)(key)(>)(symbolTransformation|symbolIndexTransformation)(</)(key)(>)'
+        - include: pop-tag-no-children
+    - match: '(<)(real)\s*(>)'
+      scope: meta.tag.xml
       captures:
-        1: meta.tag.xml punctuation.definition.tag.begin.xml
-        2: meta.tag.xml entity.name.tag.localname.xml
-        3: meta.tag.xml punctuation.definition.tag.end.xml
-        4: meta.toc-list.key.plist
-        5: meta.tag.xml punctuation.definition.tag.begin.xml
-        6: meta.tag.xml entity.name.tag.localname.xml
-        7: meta.tag.xml punctuation.definition.tag.end.xml
-      push:
-        - match: '(?=<string>)'
-          set: transformation_string
-        - include: scope:text.xml
-    - match: '(<)(key)(>)([^<]+)(</)(key)(>)'
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set:
+        - meta_content_scope: meta.inside-real.plist
+        - match: '[^\s\d<]+'
+          scope: invalid.illegal.expected-number.plist
+        - match: '\d*\.\d+'
+          scope: constant.numeric.plist
+          push:
+            - match: '[^\s<]+'
+              scope: invalid.illegal.unexpected-text.plist
+            - match: '(?=<)'
+              pop: true
+        - include: pop-tag-no-children
+  boolean:
+    - match: '(<)(true|false)\s*(/>)'
+      scope: meta.tag.xml
       captures:
-        1: meta.tag.xml punctuation.definition.tag.begin.xml
-        2: meta.tag.xml entity.name.tag.localname.xml
-        3: meta.tag.xml punctuation.definition.tag.end.xml
-        4: meta.toc-list.key.plist
-        5: meta.tag.xml punctuation.definition.tag.begin.xml
-        6: meta.tag.xml entity.name.tag.localname.xml
-        7: meta.tag.xml punctuation.definition.tag.end.xml
-    - match: '\d+(?=</(integer|real)>)'
-      scope: constant.numeric.plist
-    - match: '\d*\.\d+(?=</real>)'
-      scope: constant.numeric.plist
-    - match: '(?=</dict>)'
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml constant.language.boolean.plist
+        3: punctuation.definition.tag.end.xml
       pop: true
+  string:
+    - match: '(<)(string)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set:
+        - meta_content_scope: meta.inside-string.plist
+        - include: pop-tag-no-children
+  date:
+    - match: '(<)(date)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set:
+        - meta_content_scope: meta.inside-date.plist
+        - include: pop-tag-no-children # TODO: ISO 8601 format date i.e. "2007-04-05T14:30Z" or "2007-04-05T12:30-02:00"
+  data:
+    - match: '(<)(data)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set:
+        - meta_content_scope: meta.inside-data.plist
+        - include: pop-tag-no-children # TODO: expect base-64 only
+  empty-array:
+    - match: '(<)(array)\s*(/>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      pop: true
+  any-known-element:
+    - include: number
+    - include: boolean
+    - include: string
+    - include: date
+    - include: data
+    - include: empty-array
+    - match: '(<)(dict)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set: dict-key
+    - match: '(<)(array)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set: end-of-array
+    - include: whitespace-or-tag
+  pop-tag-no-children:
+    - match: '(</)(\2)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      pop: true
+    - match: '<(?!!)'
+      scope: punctuation.definition.tag.begin.xml
+      push: unknown-tag
     - include: scope:text.xml
-
-  regex_string:
-    - match: '(<)(string)(>)'
+  dict-key:
+    - meta_content_scope: meta.inside-dict.plist
+    - match: '(</)(dict)\s*(>)'
+      scope: meta.tag.xml
       captures:
-        1: meta.tag.xml punctuation.definition.tag.begin.xml
-        2: meta.tag.xml entity.name.tag.localname.xml
-        3: meta.tag.xml punctuation.definition.tag.end.xml
-      set:
-        - match: ']]>'
-          scope: string.unquoted.cdata.xml punctuation.definition.string.end.xml
-          pop: true
-        - match: '<!\[CDATA\['
-          scope: string.unquoted.cdata.xml punctuation.definition.string.begin.xml
-          push:
-            - meta_content_scope: meta.regex.plist
-            - include: scope:source.regexp
-          with_prototype:
-            - match: '(?=]]>)'
-              pop: true
-        - match: '(?=\S)'
-          set:
-            - meta_content_scope: meta.regex.plist
-            - include: scope:source.regexp
-          with_prototype:
-            - match: '(?=</string>)'
-              pop: true
-
-  transformation_string:
-    - match: '(<)(string)(>)'
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      pop: true
+    - match: '(<)(key)\s*(>)'
+      scope: meta.tag.xml
       captures:
-        1: meta.tag.xml punctuation.definition.tag.begin.xml
-        2: meta.tag.xml entity.name.tag.localname.xml
-        3: meta.tag.xml punctuation.definition.tag.end.xml
-      set:
-        - match: ']]>'
-          scope: string.unquoted.cdata.xml punctuation.definition.string.end.xml
-          pop: true
-        - match: '<!\[CDATA\['
-          scope: string.unquoted.cdata.xml punctuation.definition.string.begin.xml
-          push:
-            - meta_content_scope: meta.regex.transformation.plist
-            - include: transformation
-          with_prototype:
-            - match: '(?=]]>)'
-              pop: true
-        - match: '(?=\S)'
-          set:
-            - meta_content_scope: meta.regex.transformation.plist
-            - include: transformation
-          with_prototype:
-            - match: '(?=</string>)'
-              pop: true
-
-  transformation:
-    - match: 's/'
-      scope: punctuation.definition.substitute-what.plist
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      push: [any-known-element, inside-dict-key]
+    - include: whitespace-or-tag
+  inside-dict-key:
+    - meta_content_scope: meta.inside-dict-key.plist
+    - include: pop-tag-no-children
+  whitespace-or-tag:
+    - match: '(?!<!--)<'
+      scope: punctuation.definition.tag.begin.xml
+      push: unknown-tag
+    - match: '\s+'
+    - match: '[^<]+'
+      scope: invalid.illegal.unexpected-text.plist
+    - include: scope:text.xml
+  end-of-array:
+    - meta_content_scope: meta.inside-array.plist
+    - match: '(</)(array)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      pop: true
+    - match: ''
       push:
-        - match: '/'
-          scope: punctuation.definition.substitute-with.plist
-          set:
-            - match: '(/)([gimsx-]*)(;)'
-              captures:
-                1: punctuation.definition.substitute-flags.plist
-                2: storage.modifier.mode.regexp.transformation.plist
-                3: punctuation.definition.substitution.end.plist
-              pop: true
-            - include: scope:source.regexp-replacement
-        - include: scope:source.regexp#base-literal
-    - include: scope:source.regexp#group-comment
-    - include: scope:source.regexp#extended-patterns
+        - match: '(?=</array\s*>)'
+          pop: true
+        - include: any-known-element

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
@@ -158,8 +158,20 @@ contexts:
       push: [any-known-element, inside-dict-key]
     - include: scope:text.xml.plist#whitespace-or-tag
   inside-dict-key:
-    - meta_content_scope: meta.inside-dict-key.plist
-    - include: scope:text.xml.plist#pop-tag-no-children
+    - meta_content_scope: meta.inside-dict-key.plist meta.dict-key-unknown.textmateprefs
+    #- include: scope:text.xml.plist#pop-tag-no-children
+    - match: '(<)(/)(\2)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: meta.close-unknown-dict-key-tag.textmateprefs punctuation.definition.tag.begin.xml
+        2: punctuation.definition.tag.begin.xml
+        3: entity.name.tag.localname.xml
+        4: punctuation.definition.tag.end.xml
+      pop: true
+    - match: '<(?!!)'
+      scope: punctuation.definition.tag.begin.xml
+      push: scope:text.xml.plist#unknown-tag
+    - include: scope:text.xml
 
   expect-scope-string:
     - match: '(<)(string)\s*(>)'

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
@@ -1,0 +1,415 @@
+%YAML 1.2
+---
+# See http://www.sublimetext.com/docs/3/syntax.html
+file_extensions:
+  - tmPreferences
+name: TextMate Preferences (PList/XML)
+scope: text.xml.plist.textmateprefs
+contexts:
+  main:
+    - include: scope:text.xml.plist#xml-declarations
+    - match: '(<)(plist)\s*(?:(version)\s*(=)\s*(")(1.0)("))\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin
+        2: entity.name.tag.localname.xml
+        3: entity.other.attribute-name.localname.xml
+        4: punctuation.separator.key-value.xml
+        5: string.quoted.double.xml punctuation.definition.string.begin.xml
+        6: string.quoted.double.xml
+        7: string.quoted.double.xml punctuation.definition.string.end.xml
+        8: punctuation.definition.tag.end
+      push:
+        - meta_content_scope: meta.inside-plist.plist
+        - match: '(</)(plist)\s*(>)'
+          scope: meta.tag.xml
+          captures:
+            1: punctuation.definition.tag.begin.xml
+            2: entity.name.tag.localname.xml
+            3: punctuation.definition.tag.end.xml
+          set: scope:text.xml.plist#whitespace-or-tag
+        - match: '(?=\S)(?!<!--)'
+          push:
+            - include: any-known-element
+        - include: scope:text.xml
+    - include: scope:text.xml.plist#whitespace-or-tag
+  any-known-element:
+    - include: scope:text.xml.plist#number
+    - include: scope:text.xml.plist#boolean
+    - include: scope:text.xml.plist#string
+    - include: scope:text.xml.plist#empty-array
+    # NOTE: we deliberately don't include "date", or "data" here as ST doesn't support them
+    - match: '(<)(dict)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set: dict-key
+    - match: '(<)(array)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set: end-of-array
+    - include: scope:text.xml.plist#whitespace-or-tag
+  dict-key:
+    - meta_content_scope: meta.inside-dict.plist
+    - match: '(</)(dict)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      pop: true
+
+    - match: '((<)(key)\s*(>))(\s*scope\s*)((</)(key)\s*(>))'
+      captures:
+        1: meta.tag.xml
+        2: punctuation.definition.tag.begin.xml
+        3: entity.name.tag.localname.xml
+        4: punctuation.definition.tag.end.xml
+        5: meta.tag.xml
+        6: meta.inside-dict-key.plist
+        7: punctuation.definition.tag.begin.xml
+        8: entity.name.tag.localname.xml
+        9: punctuation.definition.tag.end.xml
+      push: expect-scope-string
+    - match: '((<)(key)\s*(>))(\s*(?:decreaseIndentPattern|batchDecreaseIndentPattern|increaseIndentPattern|batchIncreaseIndentPattern|disableIndentNextLinePattern|bracketIndentNextLinePattern|unIndentedLinePattern|cancelCompletion)\s*)((</)(key)\s*(>))'
+      captures:
+        1: meta.tag.xml
+        2: punctuation.definition.tag.begin.xml
+        3: entity.name.tag.localname.xml
+        4: punctuation.definition.tag.end.xml
+        5: meta.inside-dict-key.plist meta.toc-list.regex.textmateprefs
+        6: meta.tag.xml
+        7: punctuation.definition.tag.begin.xml
+        8: entity.name.tag.localname.xml
+        9: punctuation.definition.tag.end.xml
+      push: expect-regex-string
+    - match: '((<)(key)\s*(>))(\s*(?:symbolTransformation|symbolIndexTransformation)\s*)((</)(key)\s*(>))'
+      captures:
+        1: meta.tag.xml
+        2: punctuation.definition.tag.begin.xml
+        3: entity.name.tag.localname.xml
+        4: punctuation.definition.tag.end.xml
+        5: meta.inside-dict-key.plist meta.toc-list.regex-transform.textmateprefs
+        6: meta.tag.xml
+        7: punctuation.definition.tag.begin.xml
+        8: entity.name.tag.localname.xml
+        9: punctuation.definition.tag.end.xml
+      push: expect-transformation-string
+    - match: '((<)(key)\s*(>))(\s*(?:shellVariables)\s*)((</)(key)\s*(>))'
+      captures:
+        1: meta.tag.xml
+        2: punctuation.definition.tag.begin.xml
+        3: entity.name.tag.localname.xml
+        4: punctuation.definition.tag.end.xml
+        5: meta.inside-dict-key.plist meta.toc-list.shellVariables.textmateprefs
+        6: meta.tag.xml
+        7: punctuation.definition.tag.begin.xml
+        8: entity.name.tag.localname.xml
+        9: punctuation.definition.tag.end.xml
+      push: shell-variables
+    - match: '((<)(key)\s*(>))(\s*(?:showInSymbolList|showInIndexedSymbolList)\s*)((</)(key)\s*(>))'
+      captures:
+        1: meta.tag.xml
+        2: punctuation.definition.tag.begin.xml
+        3: entity.name.tag.localname.xml
+        4: punctuation.definition.tag.end.xml
+        5: meta.inside-dict-key.plist meta.toc-list.setting.textmateprefs
+        6: meta.tag.xml
+        7: punctuation.definition.tag.begin.xml
+        8: entity.name.tag.localname.xml
+        9: punctuation.definition.tag.end.xml
+      push: expect-integer # yes, integer - for some reason, booleans don't work here
+    - match: '((<)(key)\s*(>))(\s*(?:indentParens|indentSquareBrackets|preserveIndent)\s*)((</)(key)\s*(>))'
+      captures:
+        1: meta.tag.xml
+        2: punctuation.definition.tag.begin.xml
+        3: entity.name.tag.localname.xml
+        4: punctuation.definition.tag.end.xml
+        5: meta.inside-dict-key.plist meta.toc-list.setting.textmateprefs
+        6: meta.tag.xml
+        7: punctuation.definition.tag.begin.xml
+        8: entity.name.tag.localname.xml
+        9: punctuation.definition.tag.end.xml
+      push: expect-boolean
+    - match: '((<)(key)\s*(>))(\s*icon\s*)((</)(key)\s*(>))'
+      captures:
+        1: meta.tag.xml
+        2: punctuation.definition.tag.begin.xml
+        3: entity.name.tag.localname.xml
+        4: punctuation.definition.tag.end.xml
+        5: meta.inside-dict-key.plist meta.toc-list.setting.textmateprefs
+        6: meta.tag.xml
+        7: punctuation.definition.tag.begin.xml
+        8: entity.name.tag.localname.xml
+        9: punctuation.definition.tag.end.xml
+      push: expect-string
+
+    - match: '(<)(key)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      push: [any-known-element, inside-dict-key]
+    - include: scope:text.xml.plist#whitespace-or-tag
+  inside-dict-key:
+    - meta_content_scope: meta.inside-dict-key.plist
+    - include: scope:text.xml.plist#pop-tag-no-children
+
+  expect-scope-string:
+    - match: '(<)(string)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set:
+        - meta_content_scope: meta.inside-string.plist meta.toc-list.scope.textmateprefs
+        - match: '<!\[CDATA\['
+          scope: string.unquoted.cdata.xml punctuation.definition.string.begin.xml
+          push:
+            - match: ']]>'
+              scope: string.unquoted.cdata.xml punctuation.definition.string.end.xml
+              pop: true
+            - include: scope:text.scope-selector
+        - match: '(</)(string)\s*(>)'
+          scope: meta.tag.xml
+          captures:
+            1: punctuation.definition.tag.begin.xml
+            2: entity.name.tag.localname.xml
+            3: punctuation.definition.tag.end.xml
+          pop: true
+        - match: '(?=\S)'
+          push:
+            - include: scope:text.scope-selector
+          with_prototype:
+            - match: '(?=</string\s*>|<!\[CDATA\[)'
+              pop: true
+            - match: '\s*((&)amp(;))\s*'
+              captures:
+                1: constant.character.entity.xml keyword.operator.with.scope-selector
+                2: punctuation.definition.constant.xml
+                3: punctuation.definition.constant.xml
+            - include: scope:text.xml#entity
+            - match: '\s*(&)\s*'
+              captures:
+                1: invalid.illegal.bad-ampersand.xml
+    - include: scope:text.xml.plist#whitespace-or-tag
+  expect-regex-string:
+    - match: '(<)(string)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set:
+        - meta_content_scope: meta.inside-string.plist
+        - match: '(</)(string)\s*(>)'
+          scope: meta.tag.xml
+          captures:
+            1: punctuation.definition.tag.begin.xml
+            2: entity.name.tag.localname.xml
+            3: punctuation.definition.tag.end.xml
+          pop: true
+        - match: '(?=<!\[CDATA\[)'
+          push:
+            - match: ']]>'
+              scope: string.unquoted.cdata.xml punctuation.definition.string.end.xml
+              pop: true
+            - match: '<!\[CDATA\['
+              scope: string.unquoted.cdata.xml punctuation.definition.string.begin.xml
+              push: regex-pattern
+              with_prototype:
+                - match: '(?=]]>)'
+                  pop: true
+        - match: '(?=\S)'
+          push: regex-pattern
+          with_prototype:
+            - include: until-end-of-string
+    - include: scope:text.xml.plist#whitespace-or-tag
+  expect-transformation-string:
+    - match: '(<)(string)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set:
+        - meta_content_scope: meta.inside-string.plist
+        - match: '(</)(string)\s*(>)'
+          scope: meta.tag.xml
+          captures:
+            1: punctuation.definition.tag.begin.xml
+            2: entity.name.tag.localname.xml
+            3: punctuation.definition.tag.end.xml
+          pop: true
+        - match: '(?=<!\[CDATA\[)'
+          push:
+            - match: ']]>'
+              scope: string.unquoted.cdata.xml punctuation.definition.string.end.xml
+              pop: true
+            - match: '<!\[CDATA\['
+              scope: string.unquoted.cdata.xml punctuation.definition.string.begin.xml
+              push: transformation
+              with_prototype:
+                - match: '(?=]]>)'
+                  pop: true
+        - match: '(?=\S)'
+          push: transformation
+          with_prototype:
+            - include: until-end-of-string
+    - include: scope:text.xml.plist#whitespace-or-tag
+  transformation:
+    - meta_content_scope: meta.regex.transformation.textmateprefs
+    - match: 's/'
+      scope: punctuation.definition.substitute-what.textmateprefs
+      push:
+        - match: '/'
+          scope: punctuation.definition.substitute-with.textmateprefs
+          set:
+            - match: '(/)([gimsx-]*)(;|$)'
+              captures:
+                1: punctuation.definition.substitute-flags.textmateprefs
+                2: storage.modifier.mode.regexp.transformation.textmateprefs
+                3: punctuation.definition.substitution.end.textmateprefs
+              pop: true
+            - include: scope:source.regexp-replacement
+        - include: scope:source.regexp#base-literal
+    - include: scope:source.regexp#group-comment
+    - include: scope:source.regexp#extended-patterns
+  regex-pattern:
+    - meta_content_scope: meta.regex.textmateprefs
+    - include: scope:source.regexp
+  shell-variables:
+    - match: '(<)(array)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set: end-of-shell-variables-array
+    - include: scope:text.xml.plist#whitespace-or-tag
+  end-of-shell-variables-array:
+    - meta_content_scope: meta.inside-array.plist
+    - match: '(</)(array)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      pop: true
+    - match: ''
+      push:
+        - match: '(?=</array\s*>)'
+          pop: true
+        - include: expect-shell-variable-dict
+  expect-shell-variable-dict:
+    - match: '(<)(dict)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set: dict-key-shell-variable
+  dict-key-shell-variable:
+    - meta_content_scope: meta.inside-dict.shellVariables.textmateprefs
+    - match: '(</)(dict)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      pop: true
+
+    - match: '((<)(key)\s*(>))(\s*name\s*)((</)(key)\s*(>))'
+      captures:
+        1: meta.tag.xml
+        2: punctuation.definition.tag.begin.xml
+        3: entity.name.tag.localname.xml
+        4: punctuation.definition.tag.end.xml
+        5: meta.inside-dict-key.plist
+        6: meta.tag.xml
+        7: punctuation.definition.tag.begin.xml
+        8: entity.name.tag.localname.xml
+        9: punctuation.definition.tag.end.xml
+      push:
+        - match: '((<)(string)\s*(>))(\s*([^<]+)\s*)((</)(string)\s*(>))'
+          captures:
+            1: meta.tag.xml
+            2: punctuation.definition.tag.begin.xml
+            3: entity.name.tag.localname.xml
+            4: punctuation.definition.tag.end.xml
+            5: meta.inside-string.plist
+            6: meta.toc-list.shellVariable.name.textmateprefs
+            7: meta.tag.xml
+            8: punctuation.definition.tag.begin.xml
+            9: entity.name.tag.localname.xml
+            10: punctuation.definition.tag.end.xml
+          pop: true
+        - include: scope:text.xml.plist#whitespace-or-tag
+    - match: '((<)(key)\s*(>))(\s*value\s*)((</)(key)\s*(>))'
+      captures:
+        1: meta.tag.xml
+        2: punctuation.definition.tag.begin.xml
+        3: entity.name.tag.localname.xml
+        4: punctuation.definition.tag.end.xml
+        5: meta.inside-dict-key.plist
+        6: meta.tag.xml
+        7: punctuation.definition.tag.begin.xml
+        8: entity.name.tag.localname.xml
+        9: punctuation.definition.tag.end.xml
+      push: expect-string
+    - include: scope:text.xml.plist#whitespace-or-tag
+  expect-boolean:
+    - include: scope:text.xml.plist#boolean
+    - include: scope:text.xml.plist#whitespace-or-tag
+  expect-integer:
+    - include: scope:text.xml.plist#number
+    - match: '((<)(string)\s*(>))(\s*([01])\s*)((</)(string)\s*(>))'
+      captures:
+        1: meta.tag.xml
+        2: punctuation.definition.tag.begin.xml
+        3: entity.name.tag.localname.xml
+        4: punctuation.definition.tag.end.xml
+        5: meta.inside-dict-key.plist
+        6: constant.numeric.textmateprefs
+        7: meta.tag.xml
+        8: punctuation.definition.tag.begin.xml
+        9: entity.name.tag.localname.xml
+        10: punctuation.definition.tag.end.xml
+      pop: true
+    - include: scope:text.xml.plist#whitespace-or-tag
+  expect-string:
+    - include: scope:text.xml.plist#string
+    - include: scope:text.xml.plist#whitespace-or-tag
+  until-end-of-string:
+    - match: '(?=</string\s*>|<!\[CDATA\[)'
+      pop: true
+    - include: scope:text.xml#entity
+    - include: scope:text.xml#should-be-entity
+    - match: '(\\)([<>])'
+      captures:
+        1: constant.character.escape.regexp
+        2: constant.character.escape.regexp invalid.illegal.missing-entity.xml
+    - match: '\(\?([<>])'
+      captures:
+        1: invalid.illegal.missing-entity.xml
+  end-of-array:
+    - meta_content_scope: meta.inside-array.plist
+    - match: '(</)(array)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      pop: true
+    - match: ''
+      push:
+        - match: '(?=</array\s*>)'
+          pop: true
+        - include: any-known-element

--- a/Package/TextMate Preferences/syntax_test_plist.xml
+++ b/Package/TextMate Preferences/syntax_test_plist.xml
@@ -1,0 +1,97 @@
+<!-- SYNTAX TEST "Packages/PackageDev/Package/TextMate Preferences/Property List.sublime-syntax" -->
+<!-- <- comment.block.xml punctuation.definition.comment.begin.xml -->
+     <plist version="1.0">
+<!--  ^^^^^ meta.tag.xml entity.name.tag.localname.xml -->
+     <dict>
+<!-- <- meta.inside-plist.plist -->
+<!--  ^^^^ meta.tag.xml entity.name.tag.localname.xml -->
+        <key>name</key>
+<!-- <- meta.inside-plist.plist meta.inside-dict.plist -->
+<!--     ^^^ meta.tag.xml entity.name.tag.localname.xml -->
+<!--         ^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist -->
+<!--             ^^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml punctuation.definition.tag.begin.xml - meta.inside-dict-key.plist -->
+<!--               ^^^ meta.tag.xml entity.name.tag.localname.xml -->
+        <string>Test file</string>
+<!--     ^^^^^^ meta.tag.xml entity.name.tag.localname.xml -->
+<!--            ^^^^^^^^^ meta.inside-string.plist -->
+<!--                       ^^^^^^ meta.tag.xml entity.name.tag.localname.xml -->
+        <key>Test</key>
+<!--     ^^^ meta.tag.xml entity.name.tag.localname.xml - invalid -->
+<!--         ^^^^ meta.inside-dict-key.plist -->
+<!--                  ^ meta.tag.xml punctuation.definition.tag.end.xml -->
+        <true />
+<!--    ^^^^^^^^ meta.tag.xml -->
+<!--    ^ punctuation.definition.tag.begin.xml -->
+<!--     ^^^^ entity.name.tag.localname.xml constant.language.boolean.plist -->
+<!--          ^^ meta.tag.xml punctuation.definition.tag.end.xml -->
+        <key>abc</key><string>&amp; & hello <key></key></string>
+<!--                          ^^^^^ meta.inside-string.plist constant.character.entity.xml -->
+<!--                                ^ invalid.illegal.bad-ampersand.xml -->
+<!--                                         ^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+<!--                                              ^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+<!--                                                     ^ - invalid.illegal.unknown-or-unexpected-tag.plist -->
+        <key>abc</key><string><![CDATA[&amp; & hello <key></key></string>]]>test&amp;<![CDATA[cool]]></string>
+<!--                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-string.plist -->
+<!--                          ^^^^^^^^^ string.unquoted.cdata.xml punctuation.definition.string.begin.xml -->
+<!--                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.cdata.xml -->
+<!--                                                                     ^^^ string.unquoted.cdata.xml punctuation.definition.string.end.xml -->
+<!--                                                                        ^^^^^^^^^ - string.unquoted.cdata.xml -->
+<!--                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - constant.character.entity.xml - invalid.illegal - meta.tag - punctuation -->
+<!--                                                                            ^ punctuation.definition.constant.xml -->
+<!--                                                                                ^ punctuation.definition.constant.xml -->
+<!--                                                                                 ^^^^^^^^^ string.unquoted.cdata.xml punctuation.definition.string.begin.xml -->
+<!--                                                                                              ^^^ string.unquoted.cdata.xml punctuation.definition.string.end.xml -->
+<!--                                                                                                 ^^^^^^^^^ meta.tag.xml - invalid -->
+        <string>test</string>
+<!--    ^ punctuation.definition.tag.begin.xml -->
+<!--     ^^^^^^  invalid.illegal.unknown-or-unexpected-tag.plist -->
+<!--           ^ punctuation.definition.tag.end.xml -->
+<!--            ^^^^ invalid.illegal.unexpected-text.plist -->
+<!--                ^ punctuation.definition.tag.begin.xml -->
+<!--                 ^^^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+<!--                        ^ punctuation.definition.tag.end.xml -->
+        <key></key><integer>
+<!--                ^^^^^^^ meta.tag.xml entity.name.tag.localname.xml - invalid -->
+            123 456
+<!--        ^^^ meta.inside-integer.plist constant.numeric.plist -->
+<!--            ^^^ meta.inside-integer.plist invalid.illegal.unexpected-text.plist -->
+        </integer>
+<!--      ^^^^^^^ meta.tag - invalid -->
+        <key>array</array>
+<!--               ^^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+        </key><array />
+<!--    ^^^^^^^^^^^^^^^ meta.tag.xml -->
+<!--           ^^^^^ entity.name.tag.localname.xml - invalid -->
+<!--                 ^^ punctuation.definition.tag.end.xml -->
+        <key>!@#</key>
+        <array>
+<!--     ^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml entity.name.tag.localname.xml -->
+            <key></key>
+<!--         ^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+            <real>12.6</real>
+<!--              ^^^^ meta.inside-real.plist constant.numeric.plist -->
+            <dict> </dict>
+<!--              ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-array.plist meta.inside-dict.plist -->
+            <!-- test -->
+<!--        ^^^^ comment.block.xml punctuation.definition.comment.begin.xml -->
+            <false/>
+<!--         ^^^^^ constant.language.boolean.plist -->
+            <data>TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz
+IHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIGx1c3Qgb2Yg
+dGhlIG1pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY29udGlu
+dWVkIGFuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdlLCBleGNlZWRzIHRo
+ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4=</data>
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-data.plist - invalid -->
+            <date>2007-04-05T14:30Z</date>
+<!--              ^^^^^^^^^^^^^^^^^ meta.inside-date.plist - invalid -->
+            <date>22007-04-05T12:30-02:00</date>
+<!--              ^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-date.plist - invalid -->
+        </array>
+    </dict>
+<!--  ^^^^ meta.inside-plist.plist meta.tag.xml entity.name.tag.localname.xml - invalid -->
+</plist>
+<!-- ^^ meta.inside-plist.plist meta.tag.xml entity.name.tag.localname.xml - invalid -->
+test
+<!-- <- invalid.illegal.unexpected-text.plist -->
+<!-- comment -->
+<!-- <- comment.block.xml punctuation.definition.comment.begin.xml -->

--- a/Package/TextMate Preferences/syntax_test_tmPreferences.xml
+++ b/Package/TextMate Preferences/syntax_test_tmPreferences.xml
@@ -83,6 +83,11 @@
 <!--                                                     ^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml entity.name.tag.localname.xml -->
         <key>indentNextLinePattern</key>
 <!--         ^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist - meta.toc-list.regex.textmateprefs -->
+<!--                              ^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml meta.close-unknown-dict-key-tag.textmateprefs punctuation.definition.tag.begin.xml -->
+        <string>not a real key</string>
+<!--            ^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-string.plist - meta.regex.textmateprefs -->
+        <key></key>
+<!--         ^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml meta.close-unknown-dict-key-tag.textmateprefs punctuation.definition.tag.begin.xml -->
         <string>not a real key</string>
 <!--            ^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-string.plist - meta.regex.textmateprefs -->
 

--- a/Package/TextMate Preferences/syntax_test_tmPreferences.xml
+++ b/Package/TextMate Preferences/syntax_test_tmPreferences.xml
@@ -1,0 +1,121 @@
+<!-- SYNTAX TEST "Packages/PackageDev/Package/TextMate Preferences/TextMate Preferences.sublime-syntax" -->
+<!-- <- comment.block.xml punctuation.definition.comment.begin.xml -->
+     <plist version="1.0">
+<!--  ^^^^^ meta.tag.xml entity.name.tag.localname.xml -->
+     <dict>
+<!-- <- meta.inside-plist.plist -->
+        <key>scope</key>
+<!--     ^^^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml entity.name.tag.localname.xml -->
+<!--         ^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml -->
+<!--              ^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist punctuation.definition.tag.begin.xml -->
+<!--                ^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist entity.name.tag.localname.xml -->
+        <string>source.test</string>
+<!--    ^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml punctuation.definition.tag.begin.xml -->
+<!--     ^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml entity.name.tag.localname.xml -->
+<!--           ^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml punctuation.definition.tag.end.xml -->
+<!--            ^^^^^^^^^^ meta.inside-string.plist meta.toc-list.scope.textmateprefs -->
+<!--            ^^^^^^ string.unquoted.scope-segment.scope-selector -->
+<!--                         ^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml entity.name.tag.localname.xml -->
+        <key>scope</key><!-- comment -->
+<!--                    ^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist comment.block.xml -->
+        <string><![CDATA[abc & (def - ghi & jkl)]]></string>
+<!--            ^^^^^^^^^ string.unquoted.cdata.xml punctuation.definition.string.begin.xml -->
+<!--                                            ^^^ string.unquoted.cdata.xml punctuation.definition.string.end.xml -->
+<!--                     ^^^^^^^^^^^^^^^^^^^^^^^ meta.toc-list.scope.textmateprefs -->
+<!--                         ^ keyword.operator.with.scope-selector -->
+<!--                                      ^ keyword.operator.with.scope-selector -->
+        <key>scope</key>
+        <string>abc & (def - ghi & jkl &amp; mno)</string>
+<!--                ^ invalid.illegal.bad-ampersand.xml -->
+<!--                             ^ invalid.illegal.bad-ampersand.xml -->
+<!--                                   ^^^^^ constant.character.entity.xml keyword.operator.with.scope-selector -->
+
+        <key>settings</key>
+        <dict>
+            <key>shellVariables</key>
+<!--             ^^^^^^^^^^^^^^ meta.inside-dict-key.plist meta.toc-list.shellVariables.textmateprefs -->
+            <array>
+                <dict>
+                    <key>name</key>
+                    <string>TM_COMMENT_START</string>
+<!--                        ^^^^^^^^^^^^^^^^ meta.inside-string.plist meta.toc-list.shellVariable.name.textmateprefs -->
+                    <key>value</key>
+                    <string>TEST </string>
+                </dict>
+            </array>
+        </dict>
+        
+        <key>preserveIndent</key>
+<!--         ^^^^^^^^^^^^^^ meta.inside-dict-key.plist meta.toc-list.setting.textmateprefs -->
+        <false />
+<!--     ^^^^^ entity.name.tag.localname.xml constant.language.boolean.plist -->
+        <key>decreaseIndentPattern</key>
+<!--         ^^^^^^^^^^^^^^^^^^^^^ meta.inside-dict-key.plist meta.toc-list.regex.textmateprefs -->
+        <string>^\s*(?i:end|else|elseif|loop|wend|next)(\s|$)</string>
+<!--            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-string.plist meta.regex.textmateprefs -->
+<!--            ^ keyword.control.anchors.regexp -->
+<!--                                                           ^^^^^^ meta.tag.xml entity.name.tag.localname.xml -->
+        <key>increaseIndentPattern</key>
+<!--         ^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist meta.toc-list.regex.textmateprefs -->
+        <string>example containing <bad> & characters. (?<=doh)</string>
+<!--                               ^ invalid.illegal.missing-entity.xml -->
+<!--                                   ^ invalid.illegal.missing-entity.xml -->
+<!--                                     ^ invalid.illegal.bad-ampersand.xml -->
+<!--                                                 ^ keyword.other.any.regexp -->
+<!--                                                     ^ invalid.illegal.missing-entity.xml -->
+        <key>increaseIndentPattern</key>
+<!--         ^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist meta.toc-list.regex.textmateprefs -->
+        <string><![CDATA[example containing <bad> & characters. (?<=doh)]]></string>
+<!--                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-string.plist meta.regex.textmateprefs - invalid -->
+<!--            ^^^^^^^^^ string.unquoted.cdata.xml punctuation.definition.string.begin.xml - meta.regex.textmateprefs -->
+<!--                                                                    ^^^ string.unquoted.cdata.xml punctuation.definition.string.end.xml - meta.regex.textmateprefs -->
+<!--                                                             ^^^ constant.other.assertion.regexp -->
+        <key>bracketIndentNextLinePattern</key>
+        <string><![CDATA[(?x)
+            (?=wow) # this is a comment
+<!--         ^^ constant.other.assertion.regexp -->
+<!--                ^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-string.plist meta.regex.textmateprefs comment.line.number-sign.regexp -->
+        ]]></string>
+<!--    ^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-string.plist string.unquoted.cdata.xml punctuation.definition.string.end.xml -->
+<!--         ^^^^^^ meta.tag.xml entity.name.tag.localname.xml -->
+        <key>disableIndentNextLinePattern</key><string></string>
+<!--         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist meta.toc-list.regex.textmateprefs -->
+<!--                                                     ^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml entity.name.tag.localname.xml -->
+        <key>indentNextLinePattern</key>
+<!--         ^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist - meta.toc-list.regex.textmateprefs -->
+        <string>not a real key</string>
+<!--            ^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-string.plist - meta.regex.textmateprefs -->
+
+        <key>showInSymbolList</key>
+<!--         ^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist meta.toc-list.setting.textmateprefs -->
+        <integer>1</integer>text
+<!--             ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-integer.plist constant.numeric.plist -->
+<!--                        ^^^^^ meta.inside-plist.plist meta.inside-dict.plist invalid.illegal.unexpected-text.plist -->
+        <key>showInIndexedSymbolList</key>
+<!--         ^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist meta.toc-list.setting.textmateprefs -->
+        text<string>0</string>
+<!--    ^^^^ meta.inside-plist.plist meta.inside-dict.plist invalid.illegal.unexpected-text.plist -->
+<!--         ^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml entity.name.tag.localname.xml -->
+<!--                ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist constant.numeric.textmateprefs -->
+        <key>symbolTransformation</key>
+<!--         ^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist meta.toc-list.regex-transform.textmateprefs -->
+        <string><![CDATA[
+            s/(\[[^\]]*\])|\b_\b\s*|\(.*|(\s{2,})/$1(?2 )/g; (?# this is a regex transformation
+<!--        ^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-string.plist meta.regex.transformation.textmateprefs punctuation.definition.substitute-what.textmateprefs -->
+<!--                                             ^ punctuation.definition.substitute-with.textmateprefs -->
+<!--                                                 ^^ keyword.other.backref-and-recursion.conditional.regexp-replacement -->
+<!--                                                     ^ punctuation.definition.substitute-flags.textmateprefs -->
+<!--                                                      ^ storage.modifier.mode.regexp.transformation.textmateprefs -->
+<!--                                                       ^ punctuation.definition.substitution.end.textmateprefs -->
+        note that we don't end the comment, but the CDATA end still applies
+        ]]></string>
+<!--    ^^^ string.unquoted.cdata.xml punctuation.definition.string.end.xml -->
+
+    </dict>
+<!--  ^^^^ meta.inside-plist.plist meta.tag.xml entity.name.tag.localname.xml - invalid -->
+</plist>
+<!-- ^^ meta.inside-plist.plist meta.tag.xml entity.name.tag.localname.xml - invalid -->
+test
+<!-- <- invalid.illegal.unexpected-text.plist -->
+<!-- comment -->
+<!-- <- comment.block.xml punctuation.definition.comment.begin.xml -->


### PR DESCRIPTION
Now it validates a few things like:
- inside a `<dict>`, a `<key>` has to come first, followed by something else etc. followed by another `<key>` or the end of the `</dict>`
- only whitespace and comments are allowed between elements, i.e. no text except inside the leaf elements
- no attributes allowed on the elements