### PR TITLE
improve shellVariables in tmPreferences syntax

### DIFF
--- a/Package/TextMate Preferences/Symbols - shellVariable.tmPreferences
+++ b/Package/TextMate Preferences/Symbols - shellVariable.tmPreferences
@@ -2,7 +2,7 @@
 <plist version="1.0">
 <dict>
 	<key>scope</key>
-	<string>entity.name.shellVariable.tmPreferences</string>
+	<string>entity.name.shellVariable.tmPreferences, support.type.shellVariable.tmPreferences</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
@@ -349,6 +349,7 @@ contexts:
         2: entity.name.tag.localname.xml
         3: punctuation.definition.tag.end.xml
       set: inside-shell-variables-dict
+    - include: scope:text.xml.plist#whitespace-or-tag
 
   inside-shell-variables-dict:
     - meta_content_scope: meta.inside-dict.shellVariables.tmPreferences
@@ -392,6 +393,18 @@ contexts:
         8: entity.name.tag.localname.xml
         9: punctuation.definition.tag.end.xml
       push: expect-string
+    - match: '((<)(key)\s*(>))'
+      captures:
+        1: meta.tag.xml
+        2: punctuation.definition.tag.begin.xml
+        3: entity.name.tag.localname.xml
+        4: punctuation.definition.tag.end.xml
+      push: [expect-string, shell-variables-key-expect-name-or-value]
+    - include: scope:text.xml.plist#whitespace-or-tag
+
+  shell-variables-key-expect-name-or-value:
+    - meta_content_scope: invalid.deprecated.expected-name-or-value.tmPreferences
+    - include: key-end
 
   expect-boolean:
     - include: scope:text.xml.plist#boolean

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
@@ -367,18 +367,19 @@ contexts:
         8: entity.name.tag.localname.xml
         9: punctuation.definition.tag.end.xml
       push:
-        - match: '((<)(string)\s*(>))(\s*([^<]+)\s*)((</)(string)\s*(>))'
+        - match: '((<)(string)\s*(>))(\s*(?:(TM_COMMENT_(?:START|END|MODE|DISABLE_INDENT)(?:_[2-9])?)|([^<]+))\s*)((</)(string)\s*(>))'
           captures:
             1: meta.tag.xml
             2: punctuation.definition.tag.begin.xml
             3: entity.name.tag.localname.xml
             4: punctuation.definition.tag.end.xml
             5: meta.inside-value.string.plist
-            6: entity.name.shellVariable.tmPreferences
-            7: meta.tag.xml
-            8: punctuation.definition.tag.begin.xml
-            9: entity.name.tag.localname.xml
-            10: punctuation.definition.tag.end.xml
+            6: support.type.shellVariable.tmPreferences
+            7: entity.name.shellVariable.tmPreferences
+            8: meta.tag.xml
+            9: punctuation.definition.tag.begin.xml
+            10: entity.name.tag.localname.xml
+            11: punctuation.definition.tag.end.xml
           pop: true
         - include: scope:text.xml.plist#whitespace-or-tag
     - match: '((<)(key)\s*(>))(\s*value\s*)((</)(key)\s*(>))'

--- a/Package/TextMate Preferences/syntax_test_tmPreferences.xml
+++ b/Package/TextMate Preferences/syntax_test_tmPreferences.xml
@@ -55,6 +55,21 @@
                     <key>value</key>
                     <string>TEST </string>
                 </dict>
+                fg
+<!--            ^^ invalid.illegal.unexpected-text.plist -->
+                <string></string>
+<!--             ^^^^^^ invalid -->
+                <dict>
+                    <string>fg</string>
+<!--                 ^^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+                    <test>fg</test>
+<!--                 ^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+                    <key>example</key>
+<!--                     ^^^^^^^ invalid.deprecated.expected-name-or-value.tmPreferences -->
+                    <string>&amp;</string>
+<!--                 ^^^^^^ - invalid -->
+<!--                        ^^^^^ constant.character.entity.xml -->
+                </dict>
             </array>
 
             <key>preserveIndent</key>
@@ -69,12 +84,11 @@
 <!--                                                               ^^^^^^ meta.tag.xml entity.name.tag.localname.xml -->
             <key>increaseIndentPattern</key>
 <!--             ^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist entity.name.setting.regex.tmPreferences -->
-            <string>example containing <bad> & characters. (?<=doh)</string>
+            <string>example containing <bad & characters. (?<=doh)</string>
 <!--                                   ^ invalid.illegal.missing-entity.xml -->
-<!--                                       ^ invalid.illegal.missing-entity.xml -->
-<!--                                         ^ invalid.illegal.bad-ampersand.xml -->
-<!--                                                     ^ keyword.other.any.regexp -->
-<!--                                                         ^ invalid.illegal.missing-entity.xml -->
+<!--                                        ^ invalid.illegal.bad-ampersand.xml -->
+<!--                                                    ^ keyword.other.any.regexp -->
+<!--                                                        ^ invalid.illegal.missing-entity.xml -->
             <key>increaseIndentPattern</key>
 <!--             ^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist entity.name.setting.regex.tmPreferences -->
             <string><![CDATA[example containing <bad> & characters. (?<=doh)]]></string>

--- a/Package/TextMate Preferences/syntax_test_tmPreferences.xml
+++ b/Package/TextMate Preferences/syntax_test_tmPreferences.xml
@@ -51,12 +51,45 @@
 <!--                  ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict.settings.tmPreferences meta.inside-array.plist meta.inside-dict.shellVariables -->
                     <key>name</key>
                     <string>TM_COMMENT_START</string>
-<!--                        ^^^^^^^^^^^^^^^^ meta.inside-value.string.plist entity.name.shellVariable.tmPreferences -->
+<!--                        ^^^^^^^^^^^^^^^^ meta.inside-value.string.plist support.type.shellVariable.tmPreferences -->
                     <key>value</key>
                     <string>TEST </string>
                 </dict>
+                <dict>
+<!--                  ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict.settings.tmPreferences meta.inside-array.plist meta.inside-dict.shellVariables -->
+                    <key>name</key>
+                    <string>TM_COMMENT_START_2</string>
+<!--                        ^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist support.type.shellVariable.tmPreferences -->
+                    <key>value</key>
+                    <string># blah </string>
+                </dict>
+                <dict>
+<!--                  ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict.settings.tmPreferences meta.inside-array.plist meta.inside-dict.shellVariables -->
+                    <key>name</key>
+                    <string>TM_COMMENT_START_</string>
+<!--                        ^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist entity.name.shellVariable.tmPreferences -->
+                    <key>value</key>
+                    <string># blah </string>
+                </dict>
+                <dict>
+<!--                  ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict.settings.tmPreferences meta.inside-array.plist meta.inside-dict.shellVariables -->
+                    <key>name</key>
+                    <string>TM_COMMENT_DISABLE_INDENT_2</string>
+<!--                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist support.type.shellVariable.tmPreferences -->
+                    <key>value</key>
+                    <string>yes</string>
+                </dict>
+                <dict>
+<!--                  ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict.settings.tmPreferences meta.inside-array.plist meta.inside-dict.shellVariables -->
+                    <key>name</key>
+                    <string>test</string>
+<!--                        ^^^^ meta.inside-value.string.plist entity.name.shellVariable.tmPreferences -->
+                    <key>value</key>
+                    <string>test value &amp;</string>
+                </dict>
                 fg
 <!--            ^^ invalid.illegal.unexpected-text.plist -->
+<!--              ^ - invalid -->
                 <string></string>
 <!--             ^^^^^^ invalid -->
                 <dict>


### PR DESCRIPTION
- better invalid scoping when things are invalid
- distinguish between known shell variables and custom ones