### PR TITLE
don't extend syntax test highlighting past the newline character, plus refactor for efficiency

### DIFF
--- a/syntax-test_dev.py
+++ b/syntax-test_dev.py
@@ -293,7 +293,10 @@ class HighlightTestViewEventListener(sublime_plugin.ViewEventListener):
         elif col_end == col_start:
             col_end += 1
 
-        region = sublime.Region(line.begin() + col_start, line.begin() + col_end)
+        # if the tests extend past the newline character, stop highlighting at the \n
+        # as this is what these tests will assert against
+        pos_end = min(line.begin() + col_end, line.end() + 1)
+        region = sublime.Region(line.begin() + col_start, pos_end)
 
         prefs = sublime.load_settings('PackageDev.sublime-settings')
         scope = prefs.get('syntax_test_highlight_scope', 'text')


### PR DESCRIPTION
this PR ensures that the syntax test highlighting will be consistent with what ST actually asserts against when the test assertions continue past the new line character. (In this circumstance, ST asserts against the scope at the new line character.)

EDIT: i.e. it changes it from this:

![before pd](https://cloud.githubusercontent.com/assets/11882719/25043390/56a28928-2128-11e7-9485-745c95c8c5d1.png)

to this:

![after pd](https://cloud.githubusercontent.com/assets/11882719/25043393/5b7f82e8-2128-11e7-94ef-3ce15c1caa24.png)

