### PR TITLE
Highlight regex capture groups when in the captures: section.

### DIFF
--- a/syntax_def_dev.py
+++ b/syntax_def_dev.py
@@ -509,11 +509,15 @@ class SyntaxDefCompletions(sublime_plugin.EventListener):
 
         return inhibit(self.base_completions + completions)
 
+
 class SyntaxDefRegexCaptureGroupHighlighter(sublime_plugin.ViewEventListener):
     @classmethod
     def is_applicable(cls, settings):
         syntax = settings.get('syntax')
-        return syntax == 'Packages/PackageDev/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax'
+        return syntax == (
+            'Packages/PackageDev/Package/Sublime Text Syntax Definition' +
+            '/Sublime Text Syntax Definition.sublime-syntax'
+        )
 
     def on_selection_modified(self):
         self.view.add_regions('captures', list(self.get_regex_regions()), 'comment')
@@ -522,14 +526,18 @@ class SyntaxDefRegexCaptureGroupHighlighter(sublime_plugin.ViewEventListener):
         locations = [
             region.begin()
             for selection in self.view.sel()
-            if self.view.match_selector(selection.begin(), 'source.yaml.sublime.syntax meta.expect-captures.yaml')
+            if self.view.match_selector(
+                selection.begin(),
+                'source.yaml.sublime.syntax meta.expect-captures.yaml'
+            )
             for region in self.view.split_by_newlines(selection)
         ]
 
         for loc in locations:
             # Find the line number.
             match = re.search(r'(\d+):', self.view.substr(self.view.line(loc)))
-            if not match: continue
+            if not match:
+                continue
             n = int(match.group(1))
 
             # Find the associated regexp. Assume it's the preceding one.
@@ -539,7 +547,8 @@ class SyntaxDefRegexCaptureGroupHighlighter(sublime_plugin.ViewEventListener):
                     for region in self.view.find_by_selector('source.regexp.oniguruma')
                     if region.end() < loc
                 ][-1]
-            except IndexError: continue
+            except IndexError:
+                continue
 
             if n == 0:
                 yield regexp_region
@@ -560,7 +569,7 @@ class SyntaxDefRegexCaptureGroupHighlighter(sublime_plugin.ViewEventListener):
             start = None
             count = 0
             for p, i in parens:
-                if p == '(': # Not (?
+                if p == '(':  # Not (?
                     count += 1
                     if count == n:
                         start = i
@@ -570,11 +579,11 @@ class SyntaxDefRegexCaptureGroupHighlighter(sublime_plugin.ViewEventListener):
             end   = None
             depth = 0
             for p, i in parens:
-                if p in { '(', '(?' }:
+                if p in {'(', '(?'}:
                     depth += 1
                 else:
                     if depth == 0:
-                        end = i+1
+                        end = i + 1
                         break
                     else:
                         depth -= 1

--- a/syntax_def_dev.py
+++ b/syntax_def_dev.py
@@ -508,3 +508,77 @@ class SyntaxDefCompletions(sublime_plugin.EventListener):
         ]
 
         return inhibit(self.base_completions + completions)
+
+class SyntaxDefRegexCaptureGroupHighlighter(sublime_plugin.ViewEventListener):
+    @classmethod
+    def is_applicable(cls, settings):
+        syntax = settings.get('syntax')
+        return syntax == 'Packages/PackageDev/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax'
+
+    def on_selection_modified(self):
+        self.view.erase_regions('captures')
+        self.view.add_regions('captures', list(self.get_regex_regions()), 'comment')
+
+    def get_regex_regions(self):
+        locations = [
+            region.begin()
+            for selection in self.view.sel()
+            if self.view.match_selector(selection.begin(), 'source.yaml.sublime.syntax meta.expect-captures.yaml')
+            for region in self.view.split_by_newlines(selection)
+        ]
+
+        for loc in locations:
+            # Find the line number.
+            match = re.search(r'(\d+):', self.view.substr(self.view.line(loc)))
+            if not match: continue
+            n = int(match.group(1))
+
+            # Find the associated regexp. Assume it's the preceding one.
+            try:
+                regexp_region = [
+                    region
+                    for region in self.view.find_by_selector('source.regexp.oniguruma')
+                    if region.end() < loc
+                ][-1]
+            except IndexError: continue
+
+            if n == 0:
+                yield regexp_region
+                continue
+
+            # Find parens that define capture groups.
+            regexp_offset = regexp_region.begin()
+            parens = iter(
+                (match.group(), match.start() + regexp_offset)
+                for match in re.finditer(r'\(\??|\)', self.view.substr(regexp_region))
+                if self.view.match_selector(
+                    match.start() + regexp_offset,
+                    'keyword.control.group'
+                )
+            )
+
+            # Find the start of the nth capture group.
+            start = None
+            count = 0
+            for p, i in parens:
+                if p == '(': # Not (?
+                    count += 1
+                    if count == n:
+                        start = i
+                        break
+
+            # Find the end of that capture group
+            end   = None
+            depth = 0
+            for p, i in parens:
+                if p in { '(', '(?' }:
+                    depth += 1
+                else:
+                    if depth == 0:
+                        end = i+1
+                        break
+                    else:
+                        depth -= 1
+
+            if end != None:
+                yield sublime.Region(start, end)

--- a/syntax_def_dev.py
+++ b/syntax_def_dev.py
@@ -520,7 +520,29 @@ class SyntaxDefRegexCaptureGroupHighlighter(sublime_plugin.ViewEventListener):
         )
 
     def on_selection_modified(self):
-        self.view.add_regions('captures', list(self.get_regex_regions()), 'comment')
+        prefs = sublime.load_settings('PackageDev.sublime-settings')
+        scope = prefs.get('syntax_captures_highlight_scope', 'text')
+        styles = prefs.get('syntax_captures_highlight_styles', ['DRAW_NO_FILL'])
+
+        style_flags = 0
+        # the following available add_region styles are taken from the API documentation:
+        # http://www.sublimetext.com/docs/3/api_reference.html#sublime.View
+        # unfortunately, the `sublime` module doesn't encapsulate them for easy reference
+        # so we hardcode them here
+        for style in styles:
+            if style in [
+                'DRAW_EMPTY', 'HIDE_ON_MINIMAP', 'DRAW_EMPTY_AS_OVERWRITE', 'DRAW_NO_FILL',
+                'DRAW_NO_OUTLINE', 'DRAW_SOLID_UNDERLINE', 'DRAW_STIPPLED_UNDERLINE',
+                'DRAW_SQUIGGLY_UNDERLINE', 'HIDDEN', 'PERSISTENT'
+            ]:
+                style_flags |= getattr(sublime, style)
+
+        self.view.add_regions(
+            key='captures',
+            regions=list(self.get_regex_regions()),
+            scope=scope,
+            flags=style_flags,
+        )
 
     def get_regex_regions(self):
         locations = [

--- a/syntax_def_dev.py
+++ b/syntax_def_dev.py
@@ -579,5 +579,5 @@ class SyntaxDefRegexCaptureGroupHighlighter(sublime_plugin.ViewEventListener):
                     else:
                         depth -= 1
 
-            if end != None:
+            if end is not None:
                 yield sublime.Region(start, end)

--- a/syntax_def_dev.py
+++ b/syntax_def_dev.py
@@ -516,7 +516,6 @@ class SyntaxDefRegexCaptureGroupHighlighter(sublime_plugin.ViewEventListener):
         return syntax == 'Packages/PackageDev/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax'
 
     def on_selection_modified(self):
-        self.view.erase_regions('captures')
         self.view.add_regions('captures', list(self.get_regex_regions()), 'comment')
 
     def get_regex_regions(self):


### PR DESCRIPTION
Implementation for #92.

Features:
- Works with multiple selections (highlighting multiple capture groups).
- Handles nested capture groups and correctly avoids non-capturing groups.
- Should gracefully handle erroneous input, although it doesn't point it out.

Known shortcomings:
- We assume that the regexp associated with a `capture` is the last regexp before it in the file. There is surely a better solution.
- There is a bug: when you highlight multiple `capture` lines in a single selection, only the capture group associated with the first line is highlighted. All relevant capture groups should be highlighted.

Other remarks:
- This highlights the zeroth capture group, which is arguably a bad idea.
- The highlighting uses the `comment` scope, which I specified more or less at random. I'm not sure what the convention is.
- Some of the manual character-twiddling could be avoided with a little more sophistication in the regexp syntax (e.g. using `meta.group.capturing` for capturing groups).