### PR TITLE
Add support for YAML tags.

### DIFF
--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
@@ -126,11 +126,14 @@ contexts:
       push: expect_bool
 
     - include: comment
+    - include: yaml-tags-anchors
+
     - include: scope:source.yaml
 
   variables_block:
     - meta_scope: meta.block.variables.sublime-syntax
     - include: comment
+    - include: yaml-tags-anchors
     # (based on YAML.sublime-syntax#block-pair)
     - match: '^ +{{block_key_lookahead}}'
       push:
@@ -149,6 +152,7 @@ contexts:
   contexts_block:
     - meta_scope: meta.block.contexts.sublime-syntax
     - include: comment
+    - include: yaml-tags-anchors
     - include: context_definition
     - include: context_content
     - match: ^(?=\S)
@@ -238,6 +242,7 @@ contexts:
   expect_captures:
     - meta_content_scope: meta.expect-captures.yaml
     - include: comment
+    - include: yaml-tags-anchors
     - match: (\d+)\s*(:)
       captures:
         1: constant.numeric.integer.yaml
@@ -252,6 +257,7 @@ contexts:
     # ends upon EOL
     - meta_content_scope: meta.expect-scope
     - include: comment
+    - include: yaml-tags-anchors
     - match: (?={{ns_plain_first_plain_out}})
       set:
         - meta_scope: meta.scope.sublime-syntax string.unquoted.plain.out.yaml
@@ -268,6 +274,7 @@ contexts:
   expect_include:
     - meta_content_scope: meta.expect-include
     - include: comment
+    - include: yaml-tags-anchors
     - include: include
     - match: '{{block_key_lookahead_bol}}'
       pop: true
@@ -287,6 +294,7 @@ contexts:
         - match: ','
           scope: punctuation.separator.array-element.sublime-syntax
         - include: comment
+        - include: yaml-tags-anchors
         - include: include
     - include: expect_include
 
@@ -333,6 +341,7 @@ contexts:
   expect_bool:
     - meta_content_scope: meta.expect-bool
     - include: comment
+    - include: yaml-tags-anchors
     - match: \b(true|false){{_flow_scalar_end_plain_out}}
       scope: constant.language.boolean.yaml
     - match: $
@@ -341,6 +350,7 @@ contexts:
   expect_comment:
     - meta_content_scope: meta.expect-comment
     - include: comment
+    - include: yaml-tags-anchors
     - match: '"'
       scope: punctuation.definition.string.begin.yaml
       push:
@@ -394,6 +404,7 @@ contexts:
   expect_regexp:
     - meta_content_scope: meta.expect-regexp
     - include: comment
+    - include: yaml-tags-anchors
 
     # Not including the regexp syntax here because of the required double-escapes.
     # As such, double-quoting is discouraged.
@@ -495,6 +506,7 @@ contexts:
         - match: ^(?=\S)  # the block is empty
           pop: true
         - include: comment
+        - include: yaml-tags-anchors
         - match: .+
           scope: invalid.illegal.expected-comment-or-newline.yaml
 
@@ -528,3 +540,6 @@ contexts:
     - include: scope:source.regexp.oniguruma#quantifiers
     - match: ''
       pop: true
+
+  yaml-tags-anchors:
+    - include: !foo Packages/YAML/YAML.sublime-syntax#property

--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
@@ -542,4 +542,4 @@ contexts:
       pop: true
 
   yaml-tags-anchors:
-    - include: !foo Packages/YAML/YAML.sublime-syntax#property
+    - include: Packages/YAML/YAML.sublime-syntax#property

--- a/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
+++ b/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
@@ -196,3 +196,22 @@ contexts:
 
 variables:
 #^^^^^^^^ keyword.control.flow.variables.sublime-syntax
+
+contexts: !mytag
+#^^^^^^^ keyword.control.flow.contexts.sublime-syntax
+#         ^^^^^^ storage.type.tag-handle.yaml
+  main: !mytag
+# ^^^^ entity.name.context.sublime-syntax
+#       ^^^^^^ storage.type.tag-handle.yaml
+    - match: !mytag abc+
+#     ^^^^^ keyword.other.match.sublime-syntax
+#            ^^^^^^ storage.type.tag-handle.yaml
+#                   ^^^^ source.regexp.oniguruma
+      push: !mytag scope
+#     ^^^^ keyword.control.flow.push.sublime-syntax
+#           ^^^^^^ storage.type.tag-handle.yaml
+#                  ^^^^^ variable.other.sublime-syntax
+      pop: !mytag true
+#     ^^^ keyword.control.flow.pop.sublime-syntax
+#          ^^^^^^ storage.type.tag-handle.yaml
+#                 ^^^^ constant.language.boolean.yaml


### PR DESCRIPTION
For #93. Also adds support for YAML anchors, because I'm just including functionality from the YAML syntax that does both. New tests to make sure that tags don't interfere with existing highlighting.