### PR TITLE
use oniguruma regex syntax inside tmPreferences

### DIFF
--- a/Package/Sublime Text Syntax Definition/Oniguruma RegExp.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Oniguruma RegExp.sublime-syntax
@@ -177,11 +177,15 @@ contexts:
     - match: '\?(?:[ixms]*-)?[ims]+:'
       scope: storage.modifier.mode.regexp
       set: [group-body-extended, unexpected-quantifier-pop]
-    - match: \?<(\w+)>|\?'(\w+)'
+    - match: \?(<)(\w+)(>)|\?(')(\w+)(')
       scope: keyword.other.named-capture-group.regexp
       captures:
-        1: entity.name.capture-group.regexp
+        1: punctuation.definition.capture-group-name.begin.regexp
         2: entity.name.capture-group.regexp
+        3: punctuation.definition.capture-group-name.end.regexp
+        4: punctuation.definition.capture-group-name.begin.regexp
+        5: entity.name.capture-group.regexp
+        6: punctuation.definition.capture-group-name.end.regexp
     - include: group-start-common
     - match: ''
       set: [group-body-extended, unexpected-quantifier-pop]
@@ -276,19 +280,27 @@ contexts:
     - match: '\\[QEK]'
       scope: keyword.control.regexp
       push: unexpected-quantifier-pop
-    - match: \\[kg](?:<(\w+|-?\d+)>|'(\w+|-?\d+)')
+    - match: \\[kg](?:(<)(\w+|-?\d+)(>)|(')(\w+|-?\d+)('))
       scope: keyword.other.backref-and-recursion.regexp
       captures:
-        1: variable.other.backref-and-recursion.regexp
+        1: punctuation.definition.backref.begin.regexp
         2: variable.other.backref-and-recursion.regexp
+        3: punctuation.definition.backref.end.regexp
+        4: punctuation.definition.backref.begin.regexp
+        5: variable.other.backref-and-recursion.regexp
+        6: punctuation.definition.backref.end.regexp
     # back-reference with recursion level
-    - match: \\k(?:<(\w+)([+-]\d+)>|'(\w+)([+-]\d+)')
+    - match: \\k(?:(<)(\w+)([+-]\d+)(>)|(')(\w+)([+-]\d+)('))
       scope: keyword.other.backref-and-recursion.regexp
       captures:
-        1: variable.other.backref-and-recursion.regexp
-        2: constant.numeric.backref-level.regexp
-        3: variable.other.backref-and-recursion.regexp
-        4: constant.numeric.backref-level.regexp
+        1: punctuation.definition.backref.begin.regexp
+        2: variable.other.backref-and-recursion.regexp
+        3: constant.numeric.backref-level.regexp
+        4: punctuation.definition.backref.end.regexp
+        5: punctuation.definition.backref.begin.regexp
+        6: variable.other.backref-and-recursion.regexp
+        7: constant.numeric.backref-level.regexp
+        8: punctuation.definition.backref.end.regexp
     - match: \\([1-9]\d*)
       scope: keyword.other.backref-and-recursion.regexp
       captures:

--- a/Package/Sublime Text Syntax Definition/syntax_test_onig-regexp
+++ b/Package/Sublime Text Syntax Definition/syntax_test_onig-regexp
@@ -488,6 +488,6 @@ where escape characters are ignored.\).
 (?-x)
 
 check if all scopes are cleared:
-# <- (meta.literal) | - meta
+# <- meta.literal - meta meta
 
 # <- - meta

--- a/Package/Sublime Text Syntax Definition/syntax_test_onig-regexp
+++ b/Package/Sublime Text Syntax Definition/syntax_test_onig-regexp
@@ -318,28 +318,42 @@ where escape characters are ignored.\).
  \g'named_group'
 #^^^^^^^^^^^^^^^ keyword.other.backref-and-recursion.regexp
 #   ^^^^^^^^^^^ variable.other.backref-and-recursion.regexp
+#  ^ punctuation.definition.backref.begin.regexp
+#              ^ punctuation.definition.backref.end.regexp
 
  \g<named_group>
 #^^^^^^^^^^^^^^^ keyword.other.backref-and-recursion.regexp
 #   ^^^^^^^^^^^ variable.other.backref-and-recursion.regexp
+#  ^ punctuation.definition.backref.begin.regexp
+#              ^ punctuation.definition.backref.end.regexp
 
 (?x)(?<named_group>test)\g<named_group>(?-x)
 #   ^^^^^^^^^^^^^^^^^^^^ meta.group.extended
 #    ^^^^^^^^^^^^^^ keyword.other.named-capture-group.regexp
 #      ^^^^^^^^^^^ entity.name.capture-group.regexp
+#     ^ punctuation.definition.capture-group-name.begin.regexp
+#                 ^ punctuation.definition.capture-group-name.end.regexp
 #                  ^^^^ meta.literal.regexp - keyword.other.named-capture-group.regexp
 #                        ^^^^^^^^^^^^^ keyword.other.backref-and-recursion.regexp
 #                          ^^^^^^^^^^^ variable.other.backref-and-recursion.regexp
+#                         ^ punctuation.definition.backref.begin.regexp
+#                                     ^ punctuation.definition.backref.end.regexp
 
 \k'named_group+1'
 #^^^^^^^^^^^^^^^^ keyword.other.backref-and-recursion.regexp
 #  ^^^^^^^^^^^ variable.other.backref-and-recursion.regexp
 #             ^^ constant.numeric.backref-level.regexp
+# ^ punctuation.definition.backref.begin.regexp
+#               ^ punctuation.definition.backref.end.regexp
 (?:\k'named_group+1'|\k<213-1>)
 #  ^^^^^^^^^^^^^^^^^ keyword.other.backref-and-recursion.regexp
 #                ^^ constant.numeric.backref-level.regexp
+#    ^ punctuation.definition.backref.begin.regexp
+#                  ^ punctuation.definition.backref.end.regexp
 #                    ^^^^^^^^^ keyword.other.backref-and-recursion.regexp
 #                          ^^ constant.numeric.backref-level.regexp
+#                      ^ punctuation.definition.backref.begin.regexp
+#                            ^ punctuation.definition.backref.end.regexp
 
 ###################
 ## Assertions
@@ -359,7 +373,10 @@ where escape characters are ignored.\).
 #      ^ keyword.control.set.regexp
 #   ^^^ - meta.literal.regexp
 #       ^ keyword.other.any.regexp
-#        ^^^ keyword.other.backref-and-recursion.regexp
+#        ^^^^^ keyword.other.backref-and-recursion.regexp
+#          ^ punctuation.definition.backref.begin.regexp
+#           ^ variable.other.backref-and-recursion.regexp
+#            ^ punctuation.definition.backref.end.regexp
 #              ^^ meta.group.regexp meta.group.regexp storage.modifier.mode.regexp
 #                 ^ keyword.control.anchors.regexp
 #                    ^^ constant.character.escape.regexp
@@ -471,6 +488,6 @@ where escape characters are ignored.\).
 (?-x)
 
 check if all scopes are cleared:
-# <- meta.literal - meta meta
+# <- (meta.literal) | - meta
 
 # <- - meta

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
@@ -367,7 +367,7 @@ contexts:
         8: entity.name.tag.localname.xml
         9: punctuation.definition.tag.end.xml
       push:
-        - match: '((<)(string)\s*(>))(\s*((TM_COMMENT_(?:START|END|MODE|DISABLE_INDENT)(?:_[2-9])?)|(?:[^<]+))\s*)((</)(string)\s*(>))'
+        - match: '((<)(string)\s*(>))(\s*((TM_COMMENT_(?:START|END|DISABLE_INDENT)(?:_[2-9])?)|(?:[^<]+))\s*)((</)(string)\s*(>))'
           captures:
             1: meta.tag.xml
             2: punctuation.definition.tag.begin.xml

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
@@ -306,13 +306,13 @@ contexts:
                 3: punctuation.definition.substitution.end.tmPreferences
               pop: true
             - include: scope:source.regexp-replacement
-        - include: scope:source.regexp#base-literal
-    - include: scope:source.regexp#group-comment
-    - include: scope:source.regexp#extended-patterns
+        - include: scope:source.regexp.oniguruma#base-literal
+    - include: scope:source.regexp.oniguruma#group-comment
+    - include: scope:source.regexp.oniguruma#extended-patterns
 
   regex-pattern:
     - meta_content_scope: meta.regex.tmPreferences
-    - include: scope:source.regexp
+    - include: scope:source.regexp.oniguruma
 
   shell-variables:
     - include: comments

--- a/Package/TextMate Preferences/syntax_test_tmPreferences.xml
+++ b/Package/TextMate Preferences/syntax_test_tmPreferences.xml
@@ -124,11 +124,13 @@
 <!--                                                        ^ invalid.illegal.missing-entity.xml -->
             <key>increaseIndentPattern</key>
 <!--             ^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist entity.name.constant.setting.regex.tmPreferences -->
-            <string><![CDATA[example containing <bad> & characters. (?<=doh)]]></string>
+            <string><![CDATA[example containing <bad> & characters. (?<=doh)\k<test+0>]]></string>
 <!--                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-value.string.plist meta.regex.tmPreferences - invalid -->
 <!--                ^^^^^^^^^ string.unquoted.cdata.xml punctuation.definition.string.begin.xml - meta.regex.tmPreferences -->
-<!--                                                                        ^^^ string.unquoted.cdata.xml punctuation.definition.string.end.xml - meta.regex.tmPreferences -->
+<!--                                                                                  ^^^ string.unquoted.cdata.xml punctuation.definition.string.end.xml - meta.regex.tmPreferences -->
 <!--                                                                 ^^^ constant.other.assertion.regexp -->
+<!--                                                                        ^^^^^^^^^^ keyword.other.backref-and-recursion.regexp -->
+<!--                                                                               ^^ constant.numeric.backref-level.regexp -->
             <key>bracketIndentNextLinePattern</key>
             <string><![CDATA[(?x)
                 (?=wow) # this is a comment


### PR DESCRIPTION
ST uses the oniguruma regex engine/syntax inside `.tmPreferences` files, so it makes sense to change the syntax highlighting to use it, so that we will have correct/more accurate highlighting on things like [`\k<test+0>` where the capture group backreference can optionally target a particular relative recursion level](https://github.com/kkos/oniguruma/blob/36b89b9ba5c3dd90f7791c8d86517a4d8d82434c/doc/RE#L249)