### PR TITLE
helpfully highlight text as depreciated in tmPreferences files if ST will ignore it

### DIFF
--- a/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
@@ -434,6 +434,11 @@ contexts:
     - include: scope:text.xml.plist#whitespace-or-tag
 
   until-end-of-string:
+    - match: '(?=<!--)'
+      push:
+        - match: '(?!<!--)'
+          pop: true
+        - include: scope:text.xml
     - match: '(?=</string\s*>|<!\[CDATA\[)'
       pop: true
     - include: scope:text.xml#entity

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
@@ -193,36 +193,42 @@ contexts:
         2: entity.name.tag.localname.xml
         3: punctuation.definition.tag.end.xml
       set:
-        - meta_content_scope: meta.inside-value.string.plist meta.toc-list.scope.tmPreferences
-        - match: '<!\[CDATA\['
-          scope: string.unquoted.cdata.xml punctuation.definition.string.begin.xml
+        - meta_content_scope: meta.inside-value.string.plist
+        - match: (?=<!--)
           push:
-            - match: ']]>'
-              scope: string.unquoted.cdata.xml punctuation.definition.string.end.xml
+            - match: (?!<!--)
               pop: true
-            - include: scope:source.scope-selector
-        - match: '(</)(string)\s*(>)'
-          scope: meta.tag.xml
-          captures:
-            1: punctuation.definition.tag.begin.xml
-            2: entity.name.tag.localname.xml
-            3: punctuation.definition.tag.end.xml
-          pop: true
+            - include: scope:text.xml
         - match: '(?=\S)'
-          push:
-            - include: scope:source.scope-selector
-          with_prototype:
-            - match: '(?=</string\s*>|<!\[CDATA\[)'
+          set:
+            - meta_content_scope: meta.inside-value.string.plist meta.toc-list.scope.tmPreferences
+            - match: '<!\[CDATA\['
+              scope: string.unquoted.cdata.xml punctuation.definition.string.begin.xml
+              push:
+                - match: ']]>'
+                  scope: string.unquoted.cdata.xml punctuation.definition.string.end.xml
+                  set: st-end-of-string-handling
+                - include: scope:source.scope-selector
+            - match: '(</)(string)\s*(>)'
+              scope: meta.tag.xml
+              captures:
+                1: punctuation.definition.tag.begin.xml
+                2: entity.name.tag.localname.xml
+                3: punctuation.definition.tag.end.xml
               pop: true
-            - match: '\s*((&)amp(;))\s*'
-              captures:
-                1: constant.character.entity.xml keyword.operator.with.scope-selector
-                2: punctuation.definition.constant.xml
-                3: punctuation.definition.constant.xml
-            - include: scope:text.xml#entity
-            - match: '\s*(&)\s*'
-              captures:
-                1: invalid.illegal.bad-ampersand.xml
+            - match: '(?=\S)'
+              push:
+                - include: scope:source.scope-selector
+              with_prototype:
+                - match: '\s*((&)amp(;))\s*'
+                  captures:
+                    1: constant.character.entity.xml keyword.operator.with.scope-selector
+                    2: punctuation.definition.constant.xml
+                    3: punctuation.definition.constant.xml
+                - include: until-end-of-string
+                - match: '\s*(&)\s*'
+                  captures:
+                    1: invalid.illegal.bad-ampersand.xml
     - include: scope:text.xml.plist#whitespace-or-tag
 
   expect-regex-string:
@@ -234,28 +240,36 @@ contexts:
         3: punctuation.definition.tag.end.xml
       set:
         - meta_content_scope: meta.inside-value.string.plist
-        - match: '(</)(string)\s*(>)'
-          scope: meta.tag.xml
-          captures:
-            1: punctuation.definition.tag.begin.xml
-            2: entity.name.tag.localname.xml
-            3: punctuation.definition.tag.end.xml
-          pop: true
-        - match: '(?=<!\[CDATA\[)'
+        - match: (?=<!--)
           push:
-            - match: ']]>'
-              scope: string.unquoted.cdata.xml punctuation.definition.string.end.xml
+            - match: (?!<!--)
               pop: true
-            - match: '<!\[CDATA\['
-              scope: string.unquoted.cdata.xml punctuation.definition.string.begin.xml
+            - include: scope:text.xml
+        - match: '(?=\S)'
+          set:
+            - meta_content_scope: meta.inside-value.string.plist
+            - match: '(</)(string)\s*(>)'
+              scope: meta.tag.xml
+              captures:
+                1: punctuation.definition.tag.begin.xml
+                2: entity.name.tag.localname.xml
+                3: punctuation.definition.tag.end.xml
+              pop: true
+            - match: '(?=<!\[CDATA\[)'
+              push:
+                - match: ']]>'
+                  scope: string.unquoted.cdata.xml punctuation.definition.string.end.xml
+                  set: st-end-of-string-handling
+                - match: '<!\[CDATA\['
+                  scope: string.unquoted.cdata.xml punctuation.definition.string.begin.xml
+                  push: regex-pattern
+                  with_prototype:
+                    - match: '(?=]]>)'
+                      pop: true
+            - match: '(?=\S)'
               push: regex-pattern
               with_prototype:
-                - match: '(?=]]>)'
-                  pop: true
-        - match: '(?=\S)'
-          push: regex-pattern
-          with_prototype:
-            - include: until-end-of-string
+                - include: until-end-of-string
     - include: scope:text.xml.plist#whitespace-or-tag
 
   expect-transformation-string:
@@ -267,28 +281,36 @@ contexts:
         3: punctuation.definition.tag.end.xml
       set:
         - meta_content_scope: meta.inside-value.string.plist
-        - match: '(</)(string)\s*(>)'
-          scope: meta.tag.xml
-          captures:
-            1: punctuation.definition.tag.begin.xml
-            2: entity.name.tag.localname.xml
-            3: punctuation.definition.tag.end.xml
-          pop: true
-        - match: '(?=<!\[CDATA\[)'
+        - match: (?=<!--)
           push:
-            - match: ']]>'
-              scope: string.unquoted.cdata.xml punctuation.definition.string.end.xml
+            - match: (?!<!--)
               pop: true
-            - match: '<!\[CDATA\['
-              scope: string.unquoted.cdata.xml punctuation.definition.string.begin.xml
+            - include: scope:text.xml
+        - match: '(?=\S)'
+          set:
+            - meta_content_scope: meta.inside-value.string.plist
+            - match: '(</)(string)\s*(>)'
+              scope: meta.tag.xml
+              captures:
+                1: punctuation.definition.tag.begin.xml
+                2: entity.name.tag.localname.xml
+                3: punctuation.definition.tag.end.xml
+              pop: true
+            - match: '(?=<!\[CDATA\[)'
+              push:
+                - match: ']]>'
+                  scope: string.unquoted.cdata.xml punctuation.definition.string.end.xml
+                  set: st-end-of-string-handling
+                - match: '<!\[CDATA\['
+                  scope: string.unquoted.cdata.xml punctuation.definition.string.begin.xml
+                  push: transformation
+                  with_prototype:
+                    - match: '(?=]]>)'
+                      pop: true
+            - match: '(?=\S)'
               push: transformation
               with_prototype:
-                - match: '(?=]]>)'
-                  pop: true
-        - match: '(?=\S)'
-          push: transformation
-          with_prototype:
-            - include: until-end-of-string
+                - include: until-end-of-string
     - include: scope:text.xml.plist#whitespace-or-tag
 
   transformation:
@@ -430,15 +452,58 @@ contexts:
     - include: scope:text.xml.plist#whitespace-or-tag
 
   expect-string:
-    - include: scope:text.xml.plist#string
+    - match: '(<)(string)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set:
+        - meta_content_scope: meta.inside-value.string.plist
+        - match: (?=<!--)
+          push:
+            - match: (?!<!--)
+              pop: true
+            - include: scope:text.xml
+        - match: '(?=\S)'
+          set:
+            - meta_content_scope: meta.inside-value.string.plist
+            - include: handle-comments-until-end-of-string
+            - match: '(</)(string)\s*(>)'
+              scope: meta.tag.xml
+              captures:
+                1: punctuation.definition.tag.begin.xml
+                2: entity.name.tag.localname.xml
+                3: punctuation.definition.tag.end.xml
+              pop: true
+            - match: '<(?!!)'
+              scope: punctuation.definition.tag.begin.xml
+              push: scope:text.xml.plist#unknown-tag
+            - include: scope:text.xml
     - include: scope:text.xml.plist#whitespace-or-tag
 
-  until-end-of-string:
+  handle-comments-until-end-of-string:
     - match: '(?=<!--)'
+      push: st-end-of-string-handling
+
+  st-end-of-string-handling:
+    - match: '(?=</string\s*>)'
+      pop: true
+    - match: '(?=<!\[CDATA\[)'
       push:
-        - match: '(?!<!--)'
+        - meta_scope: invalid.deprecated.ignored-after-comment-or-cdata.tmPreferences
+        - match: '(?!<!\[CDATA\[)'
           pop: true
         - include: scope:text.xml
+    - match: '<(?!!)'
+      scope: punctuation.definition.tag.begin.xml
+      push: scope:text.xml.plist#unknown-tag
+    - include: scope:text.xml
+    - match: '[^<\s]+|\s+(?![\s<])'
+      scope: invalid.deprecated.ignored-after-comment-or-cdata.tmPreferences
+
+  until-end-of-string:
+    - include: handle-comments-until-end-of-string
     - match: '(?=</string\s*>|<!\[CDATA\[)'
       pop: true
     - include: scope:text.xml#entity

--- a/Package/TextMate Preferences/syntax_test_tmPreferences.xml
+++ b/Package/TextMate Preferences/syntax_test_tmPreferences.xml
@@ -61,7 +61,11 @@
                     <string>TM_COMMENT_START_2</string>
 <!--                        ^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist entity.name.constant.shellVariable.tmPreferences support.type.shellVariable.tmPreferences -->
                     <key>value</key>
-                    <string># blah </string>
+                    <string><!-- test --># blah<!-- foo -->ignored by ST</string>
+<!--                        ^^^^^^^^^^^^^ comment.block.xml -->
+<!--                                     ^^^^^^ meta.inside-value.string - comment - invalid -->
+<!--                                           ^^^^^^^^^^^^ comment.block.xml -->
+<!--                                                                    ^^^^^^^^^ meta.tag.xml -->
                 </dict>
                 <dict>
 <!--                  ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict.settings.tmPreferences meta.inside-array.plist meta.inside-dict.shellVariables -->
@@ -151,6 +155,14 @@
 <!--             ^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml meta.close-unknown-dict-key-tag.tmPreferences punctuation.definition.tag.begin.xml -->
             <string>not a real key</string>
 <!--                ^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-value.string.plist - meta.regex.tmPreferences -->
+
+            <key>cancelCompletion</key>
+<!--             ^^^^^^^^^^^^^^^^ entity.name.constant.setting.regex.tmPreferences -->
+            <string><!-- test -->.*<!-- comment -->ignored by ST</string>
+<!--                ^^^^^^^^^^^^^ comment.block.xml -->
+<!--                             ^^ meta.inside-value.string.plist - invalid - comment -->
+<!--                               ^^^^^^^^^^^^^^^^ comment.block.xml -->
+<!--                                                            ^^^^^^^^^ meta.tag.xml -->
 
             <key>showInSymbolList</key>
 <!--             ^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences -->

--- a/Package/TextMate Preferences/syntax_test_tmPreferences.xml
+++ b/Package/TextMate Preferences/syntax_test_tmPreferences.xml
@@ -61,11 +61,15 @@
                     <string>TM_COMMENT_START_2</string>
 <!--                        ^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist entity.name.constant.shellVariable.tmPreferences support.type.shellVariable.tmPreferences -->
                     <key>value</key>
-                    <string><!-- test --># blah<!-- foo -->ignored by ST</string>
-<!--                        ^^^^^^^^^^^^^ comment.block.xml -->
-<!--                                     ^^^^^^ meta.inside-value.string - comment - invalid -->
-<!--                                           ^^^^^^^^^^^^ comment.block.xml -->
-<!--                                                                    ^^^^^^^^^ meta.tag.xml -->
+                    <string>  <!-- test --># blah<!-- foo -->ignored by ST<gfg/>h</string>
+<!--                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist -->
+<!--                          ^^^^^^^^^^^^^ comment.block.xml -->
+<!--                                       ^^^^^^ - comment - invalid -->
+<!--                                             ^^^^^^^^^^^^ comment.block.xml -->
+<!--                                                         ^^^^^^^^^^^^^ invalid.deprecated -->
+<!--                                                                       ^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+<!--                                                                            ^ invalid.deprecated -->
+<!--                                                                             ^^^^^^^^^ meta.tag.xml -->
                 </dict>
                 <dict>
 <!--                  ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict.settings.tmPreferences meta.inside-array.plist meta.inside-dict.shellVariables -->
@@ -158,11 +162,26 @@
 
             <key>cancelCompletion</key>
 <!--             ^^^^^^^^^^^^^^^^ entity.name.constant.setting.regex.tmPreferences -->
-            <string><!-- test -->.*<!-- comment -->ignored by ST</string>
-<!--                ^^^^^^^^^^^^^ comment.block.xml -->
-<!--                             ^^ meta.inside-value.string.plist - invalid - comment -->
-<!--                               ^^^^^^^^^^^^^^^^ comment.block.xml -->
-<!--                                                            ^^^^^^^^^ meta.tag.xml -->
+            <string> <!-- test -->.*<!-- comment -->ignored by ST<![CDATA[test</string>]]>dfdf</string>
+<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist -->
+<!--                 ^^^^^^^^^^^^^ comment.block.xml -->
+<!--                              ^^ keyword - invalid - comment -->
+<!--                                ^^^^^^^^^^^^^^^^ comment.block.xml -->
+<!--                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid.deprecated.ignored-after-comment-or-cdata - meta.tag -->
+<!--                                                                                          ^^^^^^^^^ meta.tag.xml -->
+            <key>cancelCompletion</key>
+            <string> <![CDATA[.*]]>ignored by ST<![CDATA[<!-- test --> </string>]]>test<!-- still ignored -->here   </string>
+<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist -->
+<!--                ^ - comment - invalid - string -->
+<!--                 ^^^^^^^^^ string.unquoted.cdata.xml -->
+<!--                            ^^^ string.unquoted.cdata.xml -->
+<!--                          ^^ keyword -->
+<!--                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid.deprecated.ignored-after-comment-or-cdata -->
+<!--                               ^^^^^^^^^^^^^ - string - keyword - comment -->
+<!--                                                                                   ^^^^^^^^^^^^^^^^^^^^^^ comment.block.xml -->
+<!--                                                                                                         ^^^^ invalid.deprecated.ignored-after-comment-or-cdata -->
+<!--                                                                                                             ^^^ - invalid -->
+<!--                                                                                                                ^^^^^^^^^ meta.tag.xml -->
 
             <key>showInSymbolList</key>
 <!--             ^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences -->


### PR DESCRIPTION
Prior to this PR, the syntax definition wasn't scoping XML comments in shellVariables and regex patterns correctly. However, ST also has some odd behavior - specifically, ST ignores text in `tmPreferences` files if it comes after a comment or CDATA node that comes after non-whitespace. I have added `invalid.deprecated` scoping to highlight this to the developer, to save time troubleshooting when commenting bits of text out or trying to use multiple consecutive CDATA sections.

(`plistlib` still reads it correctly, so I haven't touched the "Property List" syntax definition - it's just ST's parser that behaves like this.)