### PR TITLE
Sublime Settings: Fix default completion of empty default string

### DIFF
--- a/plugins_/settings/known_settings.py
+++ b/plugins_/settings/known_settings.py
@@ -656,7 +656,7 @@ class KnownSettings(object):
             {(trigger, contents), ...}
                 A set of all completions.
         """
-        if not default:
+        if default is None or default is "":
             return None
         elif isinstance(default, bool):
             return {format_completion_item(True), format_completion_item(False)}

--- a/plugins_/settings/known_settings.py
+++ b/plugins_/settings/known_settings.py
@@ -34,7 +34,7 @@ def format_completion_item(value, default=False):
                                    type(value).__name__,
                                    default_str),
             # 'cast' dicts to frozen sets, because those are hashable
-            frozenset(value.items()) if isinstance(value, dict) else value)
+            frozenset(value) if isinstance(value, dict) else value)
 
 
 def sorted_completions(completions):

--- a/plugins_/settings/known_settings.py
+++ b/plugins_/settings/known_settings.py
@@ -657,7 +657,7 @@ class KnownSettings(object):
                 A set of all completions.
         """
         if default is None or default is "":
-            return None
+            return set()
         elif isinstance(default, bool):
             return {format_completion_item(True), format_completion_item(False)}
         elif isinstance(default, list):

--- a/plugins_/settings/known_settings.py
+++ b/plugins_/settings/known_settings.py
@@ -656,7 +656,7 @@ class KnownSettings(object):
             {(trigger, contents), ...}
                 A set of all completions.
         """
-        if default is None:
+        if not default:
             return None
         elif isinstance(default, bool):
             return {format_completion_item(True), format_completion_item(False)}

--- a/plugins_/settings/known_settings.py
+++ b/plugins_/settings/known_settings.py
@@ -612,11 +612,10 @@ class KnownSettings(object):
             {(trigger, contents), ...}
                 A set of all completions.
         """
+        completions = set()
         comment = self.comments.get(key)
         if not comment:
-            return set()
-
-        completions = set()
+            return completions
 
         for match in re.finditer(r"`([^`\n]+)`", comment):
             # backticks should wrap the value in JSON representation,


### PR DESCRIPTION
If the `default` is an empty string it is not None but has nothing to offer.

This causes a value like "font_face" being completed with `\t  (default) str`