### PR TITLE
Add some padding to edit settings phantoms

### DIFF
--- a/plugins_/settings/__init__.py
+++ b/plugins_/settings/__init__.py
@@ -57,7 +57,7 @@ PHANTOM_TEMPLATE = """
 <style>
     body {{
         margin: 0;
-        padding: 0;
+        padding: 0 0.2rem 0 0.2rem;
     }}
     a {{
         text-decoration: none;

--- a/plugins_/settings/__init__.py
+++ b/plugins_/settings/__init__.py
@@ -56,8 +56,9 @@ PHANTOM_TEMPLATE = """
 <body id="sublime-settings-edit">
 <style>
     body {{
+        background-color: var(--background);
         margin: 0;
-        padding: 0 0.2rem 0 0.2rem;
+        padding: 0;
     }}
     a {{
         text-decoration: none;


### PR DESCRIPTION
The padding adds some spacing to the left and right of the edit symbol to make the button look better. The symbol is rendered centered. 0.2rem should add a dpi/font-size independent relative spacing which grows with the text.