### PR TITLE
Improve SyntaxTestHighlighterListener header handling

### DIFF
--- a/plugins_/syntaxtest_dev.py
+++ b/plugins_/syntaxtest_dev.py
@@ -48,7 +48,6 @@ def get_syntax_test_tokens(view):
 
 
 class SyntaxTestHighlighterListener(sublime_plugin.ViewEventListener):
-    header = None
 
     @classmethod
     def is_applicable(cls, settings):
@@ -57,6 +56,7 @@ class SyntaxTestHighlighterListener(sublime_plugin.ViewEventListener):
 
     def __init__(self, view):
         super().__init__(view)
+        self.header = None
         self.on_modified_async()
         self.on_selection_modified_async()
 
@@ -64,7 +64,7 @@ class SyntaxTestHighlighterListener(sublime_plugin.ViewEventListener):
         # Settings were (most likely) changed to use tabs
         # or plugin was unloaded.
         # Complain about the former, if we have a test file.
-        if not self.is_applicable(self.view.settings()) and self.header:
+        if self.header and not self.is_applicable(self.view.settings()):
             _show_tab_warning()
 
     def on_modified_async(self):
@@ -74,11 +74,9 @@ class SyntaxTestHighlighterListener(sublime_plugin.ViewEventListener):
         """
 
         name = self.view.file_name()
-        if name:
-            name = path.basename(name)
-            if not name.startswith('syntax_test_'):
-                self.header = None
-                return
+        if name and not path.basename(name).startswith('syntax_test_'):
+            self.header = None
+            return
         self.header = get_syntax_test_tokens(self.view)
         # if there is no comment start token, clear the header
         if self.header and not self.header.comment_start:


### PR DESCRIPTION
While debugging #144 I found the following possible (small) improvements for the event SyntaxTestHighlighterListener.

1. The `self.header` is an object attribute and should be therefore declared in `__init__()`
2. The `self.header` is queried first in `__del__()` to avoid reading settings, if we are not within a syntax_test_...
3. Save 2 lines of code when checking syntax_test_ file name