### PR TITLE
Fix float settings values completion

### DIFF
--- a/Package/Sublime JSON/Sublime JSON.sublime-syntax
+++ b/Package/Sublime JSON/Sublime JSON.sublime-syntax
@@ -23,7 +23,7 @@ variables:
         | [1-9] \d*
       )
       (?:
-        (?: \. \d+ )?
+        (?: \. \d* )?
         (?: [eE] [+-]? \d+ )?
       )?
     )
@@ -416,7 +416,7 @@ contexts:
   mapping-value-meta:
     - clear_scopes: 1
     - meta_scope: meta.mapping.value.json
-    - match: ''
+    - match: '(?=\S)'
       pop: true
 
 

--- a/plugins_/settings/region_math.py
+++ b/plugins_/settings/region_math.py
@@ -1,13 +1,14 @@
 
 # match top-level keys only
-KEY_SCOPE = "entity.name.other.key.sublime-settings"
-KEY_COMPLETIONS_SCOPE = (
-    "meta.settings-mapping.sublime-settings - comment - meta.setting-value.sublime-settings"
-    " | " + KEY_SCOPE
-)
 VALUE_SCOPE = (
     "meta.expect-value | meta.setting-value.sublime-settings"
-    " | punctuation.separator.mapping.pair.json"
+    "| invalid.illegal.expected-value | punctuation.separator.mapping.pair.json"
+)
+
+KEY_SCOPE = "entity.name.other.key.sublime-settings"
+KEY_COMPLETIONS_SCOPE = (
+    "meta.settings-mapping.sublime-settings - comment - (" + VALUE_SCOPE + ")"
+    " | " + KEY_SCOPE
 )
 
 


### PR DESCRIPTION
This commit fixes #174 with following changes.

1. Match 1. as float even without a decimal digit in order to not pop from numbers stack to early while typing.
2. Extend the meta.mapping.value scope until the next none space character.
3. Extend the VALUE_SCOPE by `invalid.illegal.expected-value` to enable value completion in empty region between `:  ,`.
4. Make sure to exclude VALUE_SCOPE from KEY_COMPLETIONS_SCOPE to avoid key completions within the value region.