### PR TITLE
Fix: Cancel syntax test scope completions

### DIFF
--- a/Package/Default.sublime-keymap
+++ b/Package/Default.sublime-keymap
@@ -11,12 +11,16 @@
 
     /* start of syntax_dev keys */
     {
-        "keys": ["."], "command": "run_macro_file", "args": {
-            "file": "res://Packages/PackageDev/Package/Sublime Text Syntax Definition/Dot Commit Completion.sublime-macro"
-        },
-        "context": [
-             { "key": "auto_complete_visible" },
-             { "key": "selector", "operator": "equal", "operand": "meta.scope.sublime-syntax" }
+        "keys": ["enter"], "command": "packagedev_commit_scope_completion", "context": [
+            { "key": "auto_complete_visible" },
+            { "key": "selector", "operator": "equal", "operand": "meta.scope.sublime-syntax" }
+        ]
+    },
+    {
+        "keys": ["tab"], "command": "packagedev_commit_scope_completion", "context": [
+            { "key": "auto_complete_visible" },
+            { "key": "setting.tab_completion", "operator": "equal", "operand": true },
+            { "key": "selector", "operator": "equal", "operand": "meta.scope.sublime-syntax" }
         ]
     },
     /* end of syntax_dev keys */

--- a/Package/Default.sublime-keymap
+++ b/Package/Default.sublime-keymap
@@ -16,7 +16,7 @@
         },
         "context": [
              { "key": "auto_complete_visible" },
-             { "key": "selector", "operator": "equal", "operand": "source.yaml.sublime.syntax" }
+             { "key": "selector", "operator": "equal", "operand": "meta.scope.sublime-syntax" }
         ]
     },
     /* end of syntax_dev keys */

--- a/Package/Default.sublime-keymap
+++ b/Package/Default.sublime-keymap
@@ -13,13 +13,14 @@
     {
         "keys": ["enter"], "command": "packagedev_commit_scope_completion", "context": [
             { "key": "auto_complete_visible" },
+            { "key": "setting.auto_complete_commit_on_tab", "operator": "equal", "operand": false },
             { "key": "selector", "operator": "equal", "operand": "meta.scope.sublime-syntax" }
         ]
     },
     {
         "keys": ["tab"], "command": "packagedev_commit_scope_completion", "context": [
             { "key": "auto_complete_visible" },
-            { "key": "setting.tab_completion", "operator": "equal", "operand": true },
+            { "key": "setting.auto_complete_commit_on_tab", "operator": "equal", "operand": true },
             { "key": "selector", "operator": "equal", "operand": "meta.scope.sublime-syntax" }
         ]
     },

--- a/Package/Default.sublime-keymap
+++ b/Package/Default.sublime-keymap
@@ -9,6 +9,18 @@
 	},
     /* end of snippet_dev keys */
 
+    /* start of syntax_dev keys */
+    {
+        "keys": ["."], "command": "run_macro_file", "args": {
+            "file": "res://Packages/PackageDev/Package/Sublime Text Syntax Definition/Dot Commit Completion.sublime-macro"
+        },
+        "context": [
+             { "key": "auto_complete_visible" },
+             { "key": "selector", "operator": "equal", "operand": "source.yaml.sublime.syntax" }
+        ]
+    },
+    /* end of syntax_dev keys */
+
     /* start of syntax_test_dev keys */
     { "keys": ["tab"], "command": "packagedev_align_syntax_test", "context":
         [

--- a/Package/Sublime Text Syntax Definition/Dot Commit Completion.sublime-macro
+++ b/Package/Sublime Text Syntax Definition/Dot Commit Completion.sublime-macro
@@ -1,5 +1,0 @@
-[
-    { "command": "commit_completion" },
-    { "command": "insert", "args": {"characters": "."} },
-    { "command": "auto_complete", "args": { "api_completions_only": true, "disable_auto_insert": true } },
-]

--- a/Package/Sublime Text Syntax Definition/Dot Commit Completion.sublime-macro
+++ b/Package/Sublime Text Syntax Definition/Dot Commit Completion.sublime-macro
@@ -1,0 +1,5 @@
+[
+    { "command": "commit_completion" },
+    { "command": "insert", "args": {"characters": "."} },
+    { "command": "auto_complete", "args": { "api_completions_only": true, "disable_auto_insert": true } },
+]

--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
@@ -263,7 +263,10 @@ contexts:
         - meta_scope: meta.scope.sublime-syntax string.unquoted.plain.out.yaml
         - match: '{{_flow_scalar_end_plain_in}}'
           # use plain-in for when inside of an 'include-list', although not always accurate
-          pop: true
+          set:
+            - match: \n?
+              scope: meta.scope.sublime-syntax
+              pop: true
         - match: \.
           scope: punctuation.separator.scope-segments.sublime-syntax
         # TODO match common scope names?

--- a/plugins_/syntax_dev.py
+++ b/plugins_/syntax_dev.py
@@ -188,6 +188,9 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
 
         return [(base_suffix + "\tbase suffix", base_suffix)]
 
+    def on_deactivated(self):
+        self.is_completing_scope = False
+
     @_inhibit_word_completions
     def on_query_completions(self, prefix, locations):
 
@@ -304,7 +307,7 @@ class PostCompletionsListener(sublime_plugin.EventListener):
     """
 
     def on_post_text_command(self, view, command_name, args):
-        if command_name == 'hide_auto_complete':
+        if command_name in ('drag_select', 'hide_auto_complete', 'move'):
             listener = sublime_plugin.find_view_event_listener(view, SyntaxDefCompletionsListener)
             if listener:
                 listener.is_completing_scope = False

--- a/plugins_/syntax_dev.py
+++ b/plugins_/syntax_dev.py
@@ -296,6 +296,10 @@ class PackagedevCommitScopeCompletionCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         self.view.run_command("commit_completion")
 
+        # Don't add duplicated dot, if scope is edited in the middle.
+        if self.view.substr(self.view.sel()[0].a) == ".":
+            return
+
         # Check if the completed value was the base suffix
         # and don't re-open auto complete in that case.
         listener = sublime_plugin.find_view_event_listener(self.view, SyntaxDefCompletionsListener)


### PR DESCRIPTION
This PR fixes #146 by resetting `is_completing_scope` if the completion popup is closed.

The following situations reset the scope completion now:
- deactivating the view
- move away from completion by cursor ("move")
- move away from completion by mouse ("drag_select")