### PR TITLE
Fix Save command not working in "contents" of sublime-completions

### DIFF
--- a/Package/Default.sublime-keymap
+++ b/Package/Default.sublime-keymap
@@ -1,12 +1,10 @@
 [
     /* start of snippet_dev keys */
-	{
-		"keys": ["ctrl+s"], "command": "packagedev_snippet_from_raw_snippet",
-		"context":
-		[
-			{ "key": "selector", "operand": "source.sublime.snippet - text.xml.sublime.snippet" }
-		]
-	},
+    { "keys": ["ctrl+s"], "command": "packagedev_snippet_from_raw_snippet", "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "source.sublime.snippet - source.json - text.xml.sublime.snippet" }
+        ]
+    },
     /* end of snippet_dev keys */
 
     /* start of syntax_test_dev keys */

--- a/plugins_/snippet_dev.py
+++ b/plugins_/snippet_dev.py
@@ -24,7 +24,7 @@ def _insert_unindented(view, text):
 
 class PackagedevSnippetFromRawSnippetCommand(sublime_plugin.TextCommand):
     def is_enabled(self):
-        return self.view.match_selector(0, "source.sublime.snippet")
+        return self.view.match_selector(0, "source.sublime.snippet - source.json")
 
     def run(self, edit):
         content = get_text(self.view)


### PR DESCRIPTION
PackageDev provides a key binding `ctrl+s` to convert snippets.

This key binding overrides the default `save` command.

Therefore a sublime-completions file can't be saved, if the cursor is within the "contents" key as its value is scoped as `source.sublime.snippet.embedded` which matches the key binding's selector.

This commit therefore

1. extends the selector of the keybinding to exclude `source.json`
2. disables the `packagedev_snippet_from_raw_snippet` in `source.json`