### PR TITLE
Improve settings tooltip visibility for white color schemes

### DIFF
--- a/plugins_/settings/__init__.py
+++ b/plugins_/settings/__init__.py
@@ -21,22 +21,32 @@ __all__ = (
 POPUP_TEMPLATE = """
 <body id="sublime-settings">
 <style>
-    body {{
+    html.light {{
+        --html-background: color(var(--background) blend(black 91%));
+        --border-color: color(var(--html-background) blend(black 95%));
+    }}
+    html.dark {{
+        --html-background: color(var(--background) blend(white 93%));
+        --border-color: color(var(--html-background) blend(white 95%));
+    }}
+    html, body {{
         margin: 0;
         padding: 0;
+        background-color: var(--html-background);
+        color: var(--foreground);
     }}
     h1, h2 {{
-        border-bottom: 1px solid color(var(--background) blend(white 80%));
+        border-bottom: 1px solid var(--border-color);
         font-weight: normal;
         margin: 0;
         padding: 0.5rem 0.6rem;
     }}
     h1 {{
-        color: color(var(--background) blend(var(--orangish) 20%));
+        color: var(--orangish);
         font-size: 1.0rem;
     }}
     h2 {{
-        color: color(var(--background) blend(var(--foreground) 30%));
+        color: color(var(--html-background) blend(var(--foreground) 30%));
         font-size: 1.0rem;
         font-family: monospace;
     }}

--- a/plugins_/settings/known_settings.py
+++ b/plugins_/settings/known_settings.py
@@ -23,7 +23,7 @@ def html_encode(string):
                  .replace("<", "&lt;")            \
                  .replace(">", "&gt;")            \
                  .replace("\t", "&nbsp;&nbsp;")   \
-                 .replace("    ", "&nbsp;&nbsp;") \
+                 .replace("  ", "&nbsp;&nbsp;")   \
                  .replace("\n", "<br>") if string else ""
 
 


### PR DESCRIPTION
For details see the commit messages, please.


Some notes/thoughts besides commits:

I also tried to remove `background-color` attributes from the CSS and keep only the modified borders. This would: 

1. avoid to possibly override color scheme colors
2. work properly for dark color schemes as ST blends the background color well
3. but doesn't look well with white backgrounds as ST blends the background too little, which still makes them barely visible on Windows.