### PR TITLE
Add support for new embed actions in sublime-syntax files

### DIFF
--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
@@ -180,19 +180,25 @@ contexts:
         2: punctuation.separator.key-value.yaml
       push: expect_regexp
 
-    - match: (captures)\s*(:)(?=\s|$)
+    - match: (escape)\s*(:)(?=\s|$)
+      captures:
+        1: string.unquoted.plain.out.yaml keyword.other.escape.sublime-syntax
+        2: punctuation.separator.key-value.yaml
+      push: expect_regexp
+
+    - match: ((?:escape_)?captures)\s*(:)(?=\s|$)
       captures:
         1: string.unquoted.plain.out.yaml storage.type.captures.sublime-syntax
         2: punctuation.separator.key-value.yaml
       push: expect_captures
 
-    - match: (scope)\s*(:)(?=\s|$)
+    - match: ((?:embed_)?scope)\s*(:)(?=\s|$)
       captures:
         1: string.unquoted.plain.out.yaml storage.type.scope-name.sublime-syntax
         2: punctuation.separator.key-value.yaml
       push: expect_scope
 
-    - match: (include)\s*(:)(?=\s|$)
+    - match: (include|embed)\s*(:)(?=\s|$)
       captures:
         1: string.unquoted.plain.out.yaml keyword.operator.include.sublime-syntax
         2: punctuation.separator.key-value.yaml

--- a/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
+++ b/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
@@ -226,6 +226,22 @@ contexts:
 #       ^^^^^^^^^^^^^^^^^^^ meta.scope.sublime-syntax string.unquoted.block.yaml
 #           ^ punctuation.separator.scope-segments.sublime-syntax
 
+    - embed: scope:source.test
+#     ^^^^^ string.unquoted.plain.out.yaml keyword.operator.include.sublime-syntax
+#            ^^^^^ support.type.include.sublime-syntax
+    - embed_scope: meta.embedded.source.test
+#     ^^^^^^^^^^^ storage.type.scope-name.sublime-syntax
+#                  ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.scope.sublime-syntax string.unquoted.plain.out.yaml
+    - escape: foo(.)bar
+#     ^^^^^^ string.unquoted.plain.out.yaml keyword.other.escape.sublime-syntax
+#             ^^^^^^^^^^ meta.expect-regexp
+#                 ^ source.regexp.oniguruma keyword.other.any.regexp
+    - escape_captures:
+#     ^^^^^^^^^^^^^^^ storage.type.captures.sublime-syntax
+        1: keyword.other
+#          ^^^^^^^ meta.expect-captures.yaml meta.scope.sublime-syntax string.unquoted.plain.out.yaml
+#                 ^ punctuation.separator.scope-segments.sublime-syntax
+
 variables:
 #^^^^^^^^ string.unquoted.plain.out.yaml keyword.control.flow.variables.sublime-syntax
 

--- a/plugins_/syntax_dev.py
+++ b/plugins_/syntax_dev.py
@@ -150,8 +150,9 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
 
     base_completions_contexts = _build_completions(
         base_keys=('scope', 'match', 'include', 'push', 'with_prototype',  # 'pop',
+                   'embed', 'embed_scope', 'escape',
                    'meta_scope', 'meta_content_scope', 'meta_include_prototype', 'clear_scopes'),
-        dict_keys=('captures',),
+        dict_keys=('captures', 'escape_captures'),
     )
     base_completions_contexts += (("pop\tpop: true", "pop: true"),)
 


### PR DESCRIPTION
This PR adds support (syntax definition and completions) for the new `embed` actions for `.sublime-syntax` files added in build 3153.
Awesomely, no changes are required to the code that highlights capture groups in the syntax test files to support `escape_captures`.