### PR TITLE
Add support for "keyfiles" to sublime-build syntax highlighting

### DIFF
--- a/Package/Sublime Text Build System/Completions/Main Keys (in-string).sublime-completions
+++ b/Package/Sublime Text Build System/Completions/Main Keys (in-string).sublime-completions
@@ -3,5 +3,6 @@
     "completions": [
         { "trigger": "selector\tmain key", "contents": "selector" },
         { "trigger": "variants\tmain key", "contents": "variants" },
+        { "trigger": "keyfiles\tmain key", "contents": "keyfiles" },
     ]
 }

--- a/Package/Sublime Text Build System/Completions/Main Keys.sublime-completions
+++ b/Package/Sublime Text Build System/Completions/Main Keys.sublime-completions
@@ -3,5 +3,6 @@
     "completions": [
         { "trigger": "selector\tmain key", "contents": "\"selector\": \"$1\",$0" },
         { "trigger": "variants\tmain key", "contents": "\"variants\": [\n\t$0\n]," },
+        { "trigger": "keyfiles\tmain key", "contents": "\"keyfiles\": [\"$0\"]," },
     ]
 }

--- a/Package/Sublime Text Build System/Sublime Text Build System.sublime-syntax
+++ b/Package/Sublime Text Build System/Sublime Text Build System.sublime-syntax
@@ -47,6 +47,13 @@ contexts:
         2: keyword.other.main.sublime-build
         3: punctuation.definition.string.end.json
       set: [expect-variants-sequence-value, expect-colon]
+    - match: (")(keyfiles)(")
+      scope: meta.mapping.key.json meta.main-key.sublime-build string.quoted.double.json
+      captures:
+        1: punctuation.definition.string.begin.json
+        2: keyword.other.main.sublime-build
+        3: punctuation.definition.string.end.json
+      set: [expect-keyfiles-sequence-value, expect-colon]
     - include: target-key
     - include: exec-args-key
     - include: platform-key
@@ -374,6 +381,23 @@ contexts:
           scope: invalid.illegal.unclosed-string.json
           pop: true
         - include: string-escape
+
+  expect-keyfiles-sequence-value:
+    - match: (?=\[)
+      set: [mapping-value-meta, keyfiles-sequence-pop]
+    - include: expect-sequence-rest
+
+  keyfiles-sequence-pop:
+    - match: \[
+      scope: punctuation.section.sequence.begin.json
+      set:
+        - meta_scope: meta.sequence.json meta.keyfiles.collection.sublime-build
+        - include: comments
+        - match: \]
+          scope: punctuation.section.sequence.end.json
+          pop: true
+        - match: (?=\S)
+          push: [in-sequence-expect-comma, Sublime JSON.sublime-syntax#expect-string]
 
   comments:
     - include: Sublime JSON.sublime-syntax#comments

--- a/Package/Sublime Text Build System/Sublime Text Build System.sublime-syntax
+++ b/Package/Sublime Text Build System/Sublime Text Build System.sublime-syntax
@@ -93,7 +93,7 @@ contexts:
         1: punctuation.definition.string.begin.json
         2: keyword.other.main.sublime-build
         3: punctuation.definition.string.end.json
-      set: [expect-command-name-value, expect-colon]
+      set: [expect-command-name-or-dict-value, expect-colon]
 
   exec-args-key:
     - match: (")(cmd)(")
@@ -446,6 +446,10 @@ contexts:
 
   expect-command-name-value:
     - include: Sublime JSON.sublime-syntax#expect-command-name-value
+
+  expect-command-name-or-dict-value:
+    - include: Sublime JSON.sublime-syntax#command-name-pop
+    - include: expect-mapping-value
 
   mapping-value-meta:
     - clear_scopes: 1

--- a/Package/Sublime Text Build System/syntax_test_build_system.json
+++ b/Package/Sublime Text Build System/syntax_test_build_system.json
@@ -171,7 +171,14 @@
 //                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.regexp.embedded.json-string
             },
         },
-    ]
+    ],
+    
+    "cancel": "cancel_build",
+//   ^^^^^^ keyword.other.main.sublime-build
+//             ^^^^^^^^^^^^ support.constant.command-name.sublime
+    "cancel": {"kill": true},
+//             ^^^^^^ meta.mapping.key.json string.quoted.double.json
+//                     ^^^^ constant.language.boolean.json
 }
 
   ,[]//fgfg

--- a/Package/Sublime Text Build System/syntax_test_build_system.json
+++ b/Package/Sublime Text Build System/syntax_test_build_system.json
@@ -20,6 +20,15 @@
 //               ^^^^^^ string.unquoted.scope-segment.scope-selector
 //                     ^ punctuation.separator.scope-segments.scope-selector
 //                      ^^^^^^ string.unquoted.scope-segment.scope-selector
+    "keyfiles": ["Make"],
+//  ^^^^^^^^^^ meta.mapping.key.json meta.main-key.sublime-build string.quoted.double.json
+//   ^^^^^^^^ keyword.other.main.sublime-build
+//            ^ punctuation.separator.mapping.key-value.json
+//              ^^^^^^^^ meta.keyfiles.collection.sublime-build
+//              ^ punctuation.section.sequence.begin.json
+//               ^^^^^^ string.quoted.double.json
+//                     ^ punctuation.section.sequence.end.json
+//                      ^ meta.mapping.json meta.expect-comma.sublime punctuation.separator.mapping.pair.json - meta.keyfiles
 
         "other_key": "value",
 //      ^^^^^^^^^^^ meta.mapping.key.json meta.main-key.sublime-build string.quoted.double.json


### PR DESCRIPTION
while looking at https://forum.sublimetext.com/t/trying-to-create-a-debian-package-sublime-build/34430, I noticed that `keyfiles` wasn't highlighted correctly. This PR corrects that and adds the relevant completions. More info at:
- http://www.sublimetext.com/docs/3/build_systems.html#options
- https://forum.sublimetext.com/t/custom-build-system-for-rails/24609/2
- https://forum.sublimetext.com/t/build-systems/14435
- https://forum.sublimetext.com/t/dev-build-3072/14605
  