### PR TITLE
correctly scope sublime-menu platform negation operator

### DIFF
--- a/Package/Sublime Text Menu/Sublime Text Menu.sublime-syntax
+++ b/Package/Sublime Text Menu/Sublime Text Menu.sublime-syntax
@@ -128,12 +128,13 @@ contexts:
     - include: expect-string-rest
 
   platform-name-string-pop:
-    - match: (\")(Windows|Linux|OSX)(\")
+    - match: (\")(!)?(Windows|Linux|OSX)(\")
       scope: meta.platform-name.sublime-menu string.quoted.double.json
       captures:
         1: punctuation.definition.string.begin.json
-        2: support.constant.command-name.sublime-menu
-        3: punctuation.definition.string.end.json
+        2: keyword.operator.logical.sublime-menu
+        3: support.constant.command-name.sublime-menu
+        4: punctuation.definition.string.end.json
       pop: true
     - match: \" # probably illegal command name
       scope: punctuation.definition.string.begin.json

--- a/Package/Sublime Text Menu/syntax_test_menu.json
+++ b/Package/Sublime Text Menu/syntax_test_menu.json
@@ -64,7 +64,7 @@
 //                                                                   ^^^^^^^^^^ meta.mapping.key.json meta.main-key.sublime-menu string.quoted.double.json
 //                                                                    ^^^^^^^^ keyword.other.main.sublime-menu
 
-            { "command": "exit", "caption": "Quit", "mnemonic": "Q", "platform": "Linux" },
+            { "command": "exit", "caption": "Quit", "mnemonic": "Q", "platform": "!Linux" },
 // ^^^^^^^^^ invalid.illegal.expected-comma.inside-sequence.json
 //          ^ - invalid.illegal.expected-comma.inside-sequence.json
 //            ^^^^^^^^^ meta.mapping.key.json meta.main-key.sublime-menu string.quoted.double.json
@@ -77,6 +77,8 @@
 //                                                   ^^^^^^^^ keyword.other.main.sublime-menu
 //                                                                   ^^^^^^^^^^ meta.mapping.key.json meta.main-key.sublime-menu string.quoted.double.json
 //                                                                    ^^^^^^^^ keyword.other.main.sublime-menu
+//                                                                                ^ keyword.operator.logical.sublime-menu
+//                                                                                 ^^^^^ support.constant.command-name.sublime-menu - invalid
         ]
     },
 //   ^ punctuation.separator.sequence.json


### PR DESCRIPTION
this fixes a bug whereby the `Packages/Default/Main.sublime-menu` file would show `invalid` in places where the `!` operator is used for the platform specifier like:

```json
{ "command": "prompt_open_file", "caption": "Open File…", "mnemonic": "O", "platform": "!OSX" },
```