### PR TITLE
New pref to allow tabbing over whitespace during syntax test development

### DIFF
--- a/Package/PackageDev.sublime-settings
+++ b/Package/PackageDev.sublime-settings
@@ -51,4 +51,8 @@
     // "DRAW_NO_OUTLINE", "DRAW_SOLID_UNDERLINE", "DRAW_STIPPLED_UNDERLINE",
     // "DRAW_SQUIGGLY_UNDERLINE", "HIDDEN", "PERSISTENT"
     "syntax_test.highlight_styles": ["DRAW_NO_FILL"],
+    
+    // Whether to skip whitespace after the previous line's test assertions when
+    // pressing the Tab key on a new syntax test line
+    "syntax_test.skip_whitespace": false,
 }

--- a/plugins_/syntaxtest_dev.py
+++ b/plugins_/syntaxtest_dev.py
@@ -296,7 +296,9 @@ class PackagedevAlignSyntaxTestCommand(sublime_plugin.TextCommand):
 
         # find the next non-whitespace char on the line being tested above
         if skip_whitespace:
-            for pos in range(details.line_region.begin() + next_col, details.line_region.end()):
+            line_region = listener.get_details_of_line_being_tested()[1]
+            pos = line_region.begin() + next_col
+            for pos in range(pos, line_region.end()):
                 if view.substr(pos).strip() != '':
                     break
             next_col = view.rowcol(pos)[1]

--- a/plugins_/syntaxtest_dev.py
+++ b/plugins_/syntaxtest_dev.py
@@ -284,15 +284,23 @@ class PackagedevAlignSyntaxTestCommand(sublime_plugin.TextCommand):
         # find the last test assertion column on the previous line
         details = listener.get_details_of_test_assertion_line(details.line_region.begin() - 1)
         next_col = None
-        if not details.assertion_colrange:
+        skip_whitespace = get_setting('syntax_test.skip_whitespace', False)
+        if details.assertion_colrange:
+            next_col = details.assertion_colrange[1]
+        else:
             # the previous line wasn't a syntax test line, so instead
-            # find the first non-whitespace char on the line being tested above
-            for pos in range(details.line_region.begin(), details.line_region.end()):
+            # start at the first position on the line. We will then
+            # advance to the first non-whitespace char on the line.
+            next_col = 0
+            skip_whitespace = True
+
+        # find the next non-whitespace char on the line being tested above
+        if skip_whitespace:
+            for pos in range(details.line_region.begin() + next_col, details.line_region.end()):
                 if view.substr(pos).strip() != '':
                     break
             next_col = view.rowcol(pos)[1]
-        else:
-            next_col = details.assertion_colrange[1]
+
         col_diff = next_col - view.rowcol(cursor.begin())[1]
         view.insert(edit, cursor.end(), " " * col_diff)
         view.run_command('packagedev_suggest_syntax_test')


### PR DESCRIPTION
Quite often when writing syntax tests, I don't add any assertions for whitespace (unless I am adding a negation for the previous assertion to confirm the scope is no longer active), as whitespaces typically don't receive any special scopes. Therefore, when I have a file like:

```
line being tested
# ^^ example1
```

and I create a new test line and press <kbd>Tab</kbd>, I then have to press <kbd>Space</kbd><kbd>^</kbd> to get assertions for the next non-whitespace span.

```
line being tested
# ^^ example1
#   ^ base_scope
```

This PR allows me to set a new preference called `syntax_test.skip_whitespace` to `true`, so that I can just press <kbd>Tab</kbd> and end up with:

```
line being tested
# ^^ example1
#    ^^^^^ example2
```

Hopefully other people will also find this useful :)