### PR TITLE
Snippets: Highlight CDATA as self closing tag

### DIFF
--- a/Package/Sublime Text Snippet/Sublime Text Snippet.sublime-syntax
+++ b/Package/Sublime Text Snippet/Sublime Text Snippet.sublime-syntax
@@ -17,20 +17,26 @@ contexts:
         3: punctuation.definition.tag.end.xml
       push:
         - include: comments
-        - match: '<!\[CDATA\['
-          scope: punctuation.definition.string.begin.xml
+        - match: '(<!\[)(CDATA)(\[)'
+          captures:
+            1: punctuation.definition.tag.begin.xml
+            2: entity.name.tag.cdata.xml
+            3: punctuation.definition.tag.begin.xml
           set:
-            - meta_scope: string.unquoted.cdata.xml
-            - match: '\]\]>'
-              scope: punctuation.definition.string.end.xml
+            - meta_scope: meta.tag.cdata.xml
+            - meta_content_scope: string.unquoted.cdata.xml
+            - match: (?=\]\]>)
               set:
-                - include: comments
-                - match: '<!\[CDATA\['
+                - match: '\]\]>'
+                  scope: meta.tag.cdata.xml punctuation.definition.tag.end.xml
                   set:
-                    - meta_scope: invalid.illegal.multiple-cdata-not-allowed.sublime-snippet
-                    - match: '\]\]>'
-                      pop: true
-                - include: inside_content
+                    - include: comments
+                    - match: '<!\[CDATA\['
+                      push:
+                        - meta_scope: invalid.illegal.multiple-cdata-not-allowed.sublime-snippet
+                        - match: '\]\]>'
+                          pop: true
+                    - include: inside_content
             - match: ''
               push: scope:source.sublime.snippet
               with_prototype:

--- a/Package/Sublime Text Snippet/syntax_test_snippet.xml
+++ b/Package/Sublime Text Snippet/syntax_test_snippet.xml
@@ -10,8 +10,10 @@
 #   ^ punctuation.definition.tag.begin
 #           ^ punctuation.definition.tag.end
 #            ^^^^^^^^^^^^^^^^ comment.block.xml
-#                            ^^^^^^^^^^ string.unquoted.cdata - meta.tag
-#                            ^^^^^^^^^ punctuation.definition.string.begin
+#                            ^^^^^^^^^^^ meta.tag.cdata
+#                            ^^^ punctuation.definition.tag.begin
+#                               ^^^^^ entity.name.tag.cdata
+#                                    ^ punctuation.definition.tag.begin
 #                                     ^ source.sublime.snippet
       Original: ${1:Hey, Joe!}
 #               ^^^^^^^^^^^^^^ meta.text-substitution
@@ -205,7 +207,7 @@ It is possible to include a literal newline in the replacement: ${1/test/_
 # ^ keyword.other.block.end
 
  ]]>snippet<</content>
-#^^^ string.unquoted.cdata punctuation.definition.string.end
+#^^^ meta.tag.cdata punctuation.definition.tag.end
 #   ^^^^^^^ source.sublime.snippet
 #          ^ invalid.illegal.missing-entity.xml - source.sublime.snippet
 #           ^^^^^^^^^^ meta.tag - string
@@ -246,7 +248,7 @@ It is possible to include a literal newline in the replacement: ${1/test/_
 
 <content>
     <![CDATA[ example ${1} ]]>
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.cdata.xml - string.unquoted.cdata.xml string.unquoted.cdata.xml
+#            ^^^^^^^^^^^^^^ string.unquoted.cdata.xml - string.unquoted.cdata.xml string.unquoted.cdata.xml
 #                     ^^ keyword.other.block
 #                       ^ constant.numeric
 #                        ^ keyword.other.block
@@ -256,17 +258,23 @@ It is possible to include a literal newline in the replacement: ${1/test/_
 #  ^ - invalid
 #                             ^ - invalid
 </content>
-#^^^^^^^^^ meta.tag
+#^^^^^^^^^ meta.tag.xml
+# ^^^^^^^ entity.name.tag.localname.xml
 
 <content>
     <![CDATA[ example </content> ${1} ]]>
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string
-#                                        ^ - string
-#                     ^^^^^^^^^^ - meta.tag
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.cdata
+#   ^^^ punctuation.definition.tag.begin
+#      ^^^^^ entity.name.tag.cdata.xml
+#           ^ punctuation.definition.tag.begin.xml - string
+#            ^^^^^^^^^^^^^^^^^^^^^^^^^ string
+#                                     ^ - string
+#                     ^^^^^^^^^^ - entity.name.tag
 #                                ^^^^ meta.text-substitution
 #                                ^^ keyword.other.block
 #                                  ^ constant.numeric
 #                                   ^ keyword.other.block
+#                                     ^^^ punctuation.definition.tag.end
 </content>
 #^^^^^^^^^ meta.tag
 


### PR DESCRIPTION
Only the encapsulated content of a <![CDATA[ content ]]> tag should be scoped as string. By scoping the beginning and the end as ordinary xml tags the readability can be improved. The content can better be distinguished from the enclosing tag.

The <![CDATA[ is parsed by the xml-parser and marks the start of text to exclude from parsing up to the ]]> tag.

This commit implements the required changes to do so and fixes a bug which causes the </content> tag after an illegal second CDATA tag to be highlighted as illegal as well.