### PR TITLE
validate built-in command  metadata

### DIFF
--- a/plugins_/command_completions/__init__.py
+++ b/plugins_/command_completions/__init__.py
@@ -13,7 +13,8 @@ from .commandinfo import (
     get_builtin_command_meta_data,
     get_builtin_commands,
     iter_python_command_classes,
-    get_args_from_command_name
+    get_args_from_command_name,
+    validate_commands
 )
 
 __all__ = (
@@ -247,3 +248,7 @@ class SublimeTextCommandArgsCompletionPythonListener(sublime_plugin.EventListene
 
         completions = [("args\tauto-detected arguments", args)]
         return completions
+
+
+def plugin_loaded():
+    validate_commands()

--- a/plugins_/command_completions/__init__.py
+++ b/plugins_/command_completions/__init__.py
@@ -13,8 +13,7 @@ from .commandinfo import (
     get_builtin_command_meta_data,
     get_builtin_commands,
     iter_python_command_classes,
-    get_args_from_command_name,
-    validate_commands
+    get_args_from_command_name
 )
 
 __all__ = (
@@ -248,7 +247,3 @@ class SublimeTextCommandArgsCompletionPythonListener(sublime_plugin.EventListene
 
         completions = [("args\tauto-detected arguments", args)]
         return completions
-
-
-def plugin_loaded():
-    validate_commands()

--- a/plugins_/command_completions/builtin_commands_meta_data.yaml
+++ b/plugins_/command_completions/builtin_commands_meta_data.yaml
@@ -43,19 +43,11 @@ copy:
 cut:
   command_type: text
   doc_string: Cut the selected text to the clipboard.
-detect_indentation:
-  command_type: text
-  doc_string: Analyze the content of the view to detect whether tabs or spaces (and how many) are used for indentation.
 expand_selection:
   args:
     to: line|scope|brackets|indentation|tag|bol|hardbol|eol|hardeol|bof|eof|brackets
   command_type: text
   doc_string: Expand the current text caret selection(s) to the specified location.
-expand_tabs:
-  args:
-    set_translate_tabs: true
-  command_type: text
-  doc_string: Convert tab characters to spaces everywhere in the view.
 find_all_under:
   command_type: text
   doc_string: Seach and select all text matches, which are the same as the text selected text or the word under the caret.
@@ -334,11 +326,6 @@ toggle_side_bar:
 undo:
   command_type: text
   doc_string: Undo the last action.
-unexpand_tabs:
-  args:
-    set_translate_tabs: true
-  command_type: text
-  doc_string: Convert spaces to tabs everywhere in the view according to the tab_width setting.
 unindent:
   command_type: text
   doc_string: Unindent the selection by one level.

--- a/plugins_/command_completions/commandinfo.py
+++ b/plugins_/command_completions/commandinfo.py
@@ -88,6 +88,17 @@ def get_builtin_commands(command_type=""):
         result = frozenset(k for k, v in meta.items()
                            if v['command_type'] == command_type)
 
+    for c in iter_python_command_classes(command_type):
+        name = get_command_name(c)
+        module = c.__module__
+        package = module.split(".")[0]
+        if package == 'Default':
+            if name in result:
+                l.warning(
+                    'command "{name}" in the {package} package is defined in the built-in '
+                    'metadata file, probably it should not be'.format(name=name, package=package)
+                )
+
     return result
 
 
@@ -187,25 +198,3 @@ def get_args_from_command_name(command_name):
             return extract_command_class_args(command_class)
         else:
             return None  # the command is not defined
-
-
-def validate_commands():
-    custom_data = get_builtin_commands()
-    if len(custom_data) == 0:
-        l.warning('unable to load command metadata, command metadata validation failed.')
-        return False
-
-    failures = False
-    for c in iter_python_command_classes():
-        name = get_command_name(c)
-        module = c.__module__
-        package = module.split(".")[0]
-        if package == 'Default':
-            if name in custom_data:
-                failures = True
-                l.warning(
-                    'command "{name}" in the {package} package is defined in the built-in'
-                    'metadata file, probably it should not be'.format(name=name, package=package)
-                )
-
-    return not failures

--- a/plugins_/command_completions/commandinfo.py
+++ b/plugins_/command_completions/commandinfo.py
@@ -187,3 +187,25 @@ def get_args_from_command_name(command_name):
             return extract_command_class_args(command_class)
         else:
             return None  # the command is not defined
+
+
+def validate_commands():
+    custom_data = get_builtin_commands()
+    if len(custom_data) == 0:
+        l.warning('unable to load command metadata, command metadata validation failed.')
+        return False
+
+    failures = False
+    for c in iter_python_command_classes():
+        name = get_command_name(c)
+        module = c.__module__
+        package = module.split(".")[0]
+        if package == 'Default':
+            if name in custom_data:
+                failures = True
+                l.warning(
+                    'command "{name}" in the {package} package is defined in the built-in'
+                    'metadata file, probably it should not be'.format(name=name, package=package)
+                )
+
+    return not failures


### PR DESCRIPTION
This PR ensures that when the PackageDev `command_completions` plugin is loaded, it will check that the metadata could be loaded successfully, and warn if it couldn't. It will also log a warning if the metadata file, which is supposed to contain built-in (core) commands only, contains a command defined in the `Default` package. This will allow PackageDev developers to make changes to the metadata file, restart ST and confirm (from looking at the ST console) that the file is still parse-able and doesn't contain any mistakes. It also highlights that I shouldn't have added the indentation related commands in https://github.com/SublimeText/PackageDev/pull/190, as I forgot they exist in the `Default` package. (For some reason they weren't showing up as completions when I was trying something out the other day, which is what inspired me to add them.)

@FichteFoll, if we don't want it to parse the metadata on plugin load, and instead defer it to later - when the file is actually read through normal use of the plugin, that's fine by me - my main goal here is to have a way to confirm that the metadata file is correct, and if it doesn't validate automatically but I can still execute the verification routine manually on demand, then that is fine by me.

Unfortunately I don't think we'll be able to set up the CI to spot check this for PRs, but if you can think of a way that'd be great! ;)