### PR TITLE
Use transparent background for settings phantoms

### DIFF
--- a/plugins_/settings/__init__.py
+++ b/plugins_/settings/__init__.py
@@ -68,7 +68,7 @@ PHANTOM_TEMPLATE = """
     html, body {{
         margin: 0;
         padding: 0;
-        background-color: var(--background);
+        background-color: transparent;
     }}
     a {{
         text-decoration: none;


### PR DESCRIPTION
The `edit` phantoms in the _*.sublime-settings_ files are set to the view's background color at the moment, which does not match the rendered background color in several situations:

   - text selected
   - active line background differs from view background

To fix the graphical glitches a fully transparent background is applied via CSS.