### PR TITLE
Fix: sublime-color-scheme main key completions

### DIFF
--- a/Package/Sublime Text Color Scheme/Completions/Main Keys.sublime-completions
+++ b/Package/Sublime Text Color Scheme/Completions/Main Keys.sublime-completions
@@ -1,5 +1,5 @@
 {
-    "scope": "meta.color-scheme.collection.sublime-color-scheme - meta.mapping meta.mapping - string - comment",
+    "scope": "meta.color-scheme.collection.sublime-color-scheme - meta.globals - meta.rules - meta.variables - meta.mapping.value - string - comment",
     "completions": [
         { "trigger": "variables\tmain key", "contents": "\"variables\": {\n\t\"$1\": \"$2\",$0\n}," },
         { "trigger": "globals\tmain key", "contents": "\"globals\": {\n\t$0\n}," },

--- a/Package/Sublime Text Color Scheme/Completions/Main Keys.sublime-completions
+++ b/Package/Sublime Text Color Scheme/Completions/Main Keys.sublime-completions
@@ -1,5 +1,5 @@
 {
-    "scope": "meta.color-scheme.collection.sublime-color-scheme - meta.globals - meta.rules - meta.variables - meta.mapping.value - string - comment",
+    "scope": "meta.color-scheme.collection.sublime-color-scheme - meta.mapping meta.mapping - meta.mapping meta.sequence - string - comment",
     "completions": [
         { "trigger": "variables\tmain key", "contents": "\"variables\": {\n\t\"$1\": \"$2\",$0\n}," },
         { "trigger": "globals\tmain key", "contents": "\"globals\": {\n\t$0\n}," },

--- a/Package/Sublime Text Color Scheme/Completions/Main Keys.sublime-completions
+++ b/Package/Sublime Text Color Scheme/Completions/Main Keys.sublime-completions
@@ -1,5 +1,5 @@
 {
-    "scope": "meta.color-scheme.collection.sublime-color-scheme - meta.mapping meta.mapping - meta.mapping meta.sequence - string - comment",
+    "scope": "meta.color-scheme.collection.sublime-color-scheme - meta.mapping meta.mapping - meta.sequence - string - comment",
     "completions": [
         { "trigger": "variables\tmain key", "contents": "\"variables\": {\n\t\"$1\": \"$2\",$0\n}," },
         { "trigger": "globals\tmain key", "contents": "\"globals\": {\n\t$0\n}," },


### PR DESCRIPTION
The main-keys of a sublime-color-scheme are currently being suggested within themselves.

This commit changes the selector to suggest main keys only within the top-level object where such keys are actually valid only.