### PR TITLE
Use sublime_lib.flags.RegionOption for style flags.

### DIFF
--- a/plugins_/lib/flags.py
+++ b/plugins_/lib/flags.py
@@ -1,17 +1,6 @@
 import logging
-import sublime
 
-
-# The following available add_region styles are taken from the API documentation:
-# http://www.sublimetext.com/docs/3/api_reference.html#sublime.View
-# unfortunately, the `sublime` module doesn't encapsulate them for easy reference
-# so we hardcode them here.
-# TODO use `enum` lib
-ADD_REGION_STYLE_NAMES = {
-    'DRAW_EMPTY', 'HIDE_ON_MINIMAP', 'DRAW_EMPTY_AS_OVERWRITE', 'DRAW_NO_FILL',
-    'DRAW_NO_OUTLINE', 'DRAW_SOLID_UNDERLINE', 'DRAW_STIPPLED_UNDERLINE',
-    'DRAW_SQUIGGLY_UNDERLINE', 'HIDDEN', 'PERSISTENT',
-}
+from sublime_lib.flags import RegionOption
 
 logger = logging.getLogger(__name__)
 
@@ -21,8 +10,8 @@ def style_flags_from_list(style_list):
     if not isinstance(style_list, list):
         raise TypeError("Expected style *list*")
     for style in style_list:
-        if style in ADD_REGION_STYLE_NAMES:
-            style_flags |= getattr(sublime, style)
-        else:
+        try:
+            style_flags |= RegionOption[style]
+        except KeyError:
             logger.debug("Style flag %r doesn't exist", style)
     return style_flags


### PR DESCRIPTION
Parsing a list of flag strings sounds like something we might want to add to sublime_lib. The implementation would be:

```python
class BetterIntFlag(IntFlag):
    @classmethod
    def parse(cls, items):
        value = cls(0)
        for item in items:
            value |= cls[item]
        return value
```

This would obviate the need for `flags.py`. Code like `style_flags = style_flags_from_list(styles)` would be replaced by `style_flags = RegionOption.parse(styles)`.