### PR TITLE
"target" changed to "file"

### DIFF
--- a/plugins_/new_resource_file/templates.py
+++ b/plugins_/new_resource_file/templates.py
@@ -90,7 +90,7 @@ TEMPLATES = dict(
               { "caption": "README",
                 "command": "open_file",
                 "args": {
-                  "target": "\${packages}/$1/README.md"
+                  "file": "\${packages}/$1/README.md"
                 }
               },
               { "caption": "-" },


### PR DESCRIPTION
`target` does not work as the argument. `open_file` expects `file`.