### PR TITLE
Fix Context completions in multi-push statements not displayed

### DIFF
--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
@@ -378,7 +378,7 @@ contexts:
               scope: punctuation.separator.context-name.sublime-syntax
               set: expect_include
         # absolute includes
-        - match: \w((?!\s#|:\s).)+\.sublime-syntax(?=\s*(#|$))
+        - match: \w((?!\s#|:\s)[^{{c_flow_indicator}}])+\.sublime-syntax(?=\s*(#|$))
           scope: support.module.file-path.sublime-syntax
           set:
             - match: '{{_flow_scalar_end_plain_in}}'

--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
@@ -316,7 +316,6 @@ contexts:
       pop: true
 
   expect_include_list:
-    # only flow list for now, or plain string
     - meta_content_scope: meta.expect-include-list
     - match: \[
       scope: punctuation.definition.array.begin.sublime-syntax
@@ -330,16 +329,34 @@ contexts:
         - include: comment
         - include: yaml-tags-anchors
         - include: include
-    - match: \-(?=\s*{{plain_scalar_but_not_block_key}})
-      scope: punctuation.definition.block.sequence.yaml
-      push:
-        - meta_scope: meta.include-list.sublime-syntax meta.flow-sequence.yaml
-        - match: $\n?
-          pop: true
+    - match: ^
+      set:
+        - meta_scope: meta.expect-include-list-or-content
         - include: comment
-        - include: yaml-tags-anchors
-        - include: include
+        - include: yaml-block-sequence
+        # first item after push/set looks like an included context
+        - match: ^([ ]+)(?=-\s*{{plain_scalar_but_not_block_key}})
+          set:
+            - meta_content_scope: meta.expect-include-list-or-content meta.include-list.sublime-syntax
+            - include: include_list_content
+            - match: ^(?=([ ]+)-)
+              set:
+                - meta_scope: meta.include-list.sublime-syntax
+                - include: include_list_content
+        # limit context to the current line
+        - match: $|(?=\S)
+          pop: true
     - include: expect_include
+
+  include_list_content:
+    - include: comment
+    - include: include
+    - include: yaml-block-sequence
+    # pop off at none-empty line with different indention than first include item
+    - match: ^(?!(\s*$|\1-))
+      pop: true
+    - match: \S.+$
+      scope: invalid.illegal.include.sublime-syntax
 
   include:
     - match: '{{plain_scalar_but_not_block_key}}'
@@ -583,6 +600,9 @@ contexts:
     - include: Oniguruma RegExp.sublime-syntax#quantifiers
     - match: ''
       pop: true
+
+  yaml-block-sequence:
+    - include: YAML.sublime-syntax#block-sequence
 
   yaml-tags-anchors:
     - include: YAML.sublime-syntax#property

--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
@@ -310,13 +310,13 @@ contexts:
     - include: comment
     - include: yaml-tags-anchors
     - include: include
-    - match: '{{block_key_lookahead_bol}}'
-      pop: true
-    - match: (?=\S)
+    - match: $|(?=\S)
       pop: true
 
   expect_include_list:
     - meta_content_scope: meta.expect-include-list
+    - include: comment
+    - include: yaml-tags-anchors
     - match: \[
       scope: punctuation.definition.array.begin.sublime-syntax
       set:
@@ -346,7 +346,8 @@ contexts:
         # limit context to the current line
         - match: $|(?=\S)
           pop: true
-    - include: expect_include
+    - match: (?=\S)
+      set: expect_include
 
   include_list_content:
     - include: comment

--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
@@ -330,6 +330,15 @@ contexts:
         - include: comment
         - include: yaml-tags-anchors
         - include: include
+    - match: \-(?=\s*{{plain_scalar_but_not_block_key}})
+      scope: punctuation.definition.block.sequence.yaml
+      push:
+        - meta_scope: meta.include-list.sublime-syntax meta.flow-sequence.yaml
+        - match: $\n?
+          pop: true
+        - include: comment
+        - include: yaml-tags-anchors
+        - include: include
     - include: expect_include
 
   include:

--- a/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
+++ b/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
@@ -264,6 +264,23 @@ contexts: !mytag
 #          ^^^^^^ storage.type.tag-handle.yaml
 #                 ^^^^ constant.language.boolean.yaml
 
+    - match: foo
+#   ^ meta.block.contexts.sublime-syntax punctuation.definition.block.sequence.item.yaml
+#     ^^^^^ meta.block.contexts.sublime-syntax string.unquoted.plain.out.yaml keyword.other.match.sublime-syntax
+      push:
+#     ^^^^ meta.block.contexts.sublime-syntax string.unquoted.plain.out.yaml keyword.control.flow.push.sublime-syntax
+        - context-name-3
+#       ^^^^^^^^^^^^^^^^^ meta.block.contexts.sublime-syntax meta.expect-include-list meta.include-list.sublime-syntax meta.flow-sequence.yaml
+#       ^ punctuation.definition.block.sequence.yaml
+#         ^^^^^^^^^^^^^^ meta.include.sublime-syntax string.unquoted.plain.out.yaml variable.other.sublime-syntax
+        - context-name-2
+#       ^^^^^^^^^^^^^^^^^ meta.block.contexts.sublime-syntax meta.expect-include-list meta.include-list.sublime-syntax meta.flow-sequence.yaml
+#       ^ punctuation.definition.block.sequence.yaml
+#         ^^^^^^^^^^^^^^ meta.include.sublime-syntax string.unquoted.plain.out.yaml variable.other.sublime-syntax
+    - match: foo
+#   ^ meta.block.contexts.sublime-syntax punctuation.definition.block.sequence.item.yaml
+#     ^^^^^ meta.block.contexts.sublime-syntax string.unquoted.plain.out.yaml keyword.other.match.sublime-syntax
+
       pop:not a key
 #     ^^^ - keyword
 variables:also not a key

--- a/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
+++ b/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
@@ -121,6 +121,9 @@ contexts:
 # ^^^^ entity.name.context.sublime-syntax
     - include: scope:source.json
 #     ^^^^^^^ string.unquoted.plain.out.yaml keyword.operator.include.sublime-syntax
+    - match:
+#<- - meta.expect-include - meta.expect-include-list-or-content - meta.expect-include-list
+
   context_name:
 # ^^^^^^^^^^^^ entity.name.context.sublime-syntax
     - captures:
@@ -135,31 +138,38 @@ contexts:
     # Context mangling (also includes)
     - include: "Packages/JSON/JSON.sublime-syntax"
     - include: Packages/JSON/JSON.sublime-syntax#comment
+#<- - meta.expect-include - meta.expect-include-list-or-content - meta.expect-include-list
 #              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.include.sublime-syntax string
 #              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ support.module.file-path.sublime-syntax
 #                                               ^ punctuation.separator.context-name.sublime-syntax - comment
 #                                                ^^^^^^^ variable.other.sublime-syntax
     - include: JSON.sublime-syntax#comments
+#<- - meta.expect-include - meta.expect-include-list-or-content - meta.expect-include-list
 #              ^^^^^^^^^^^^^^^^^^^ support.module.file-path.sublime-syntax
 #                                 ^ punctuation.separator.context-name.sublime-syntax
 #                                  ^^^^^^^ variable.other.sublime-syntax
 
     - include: Packages/JSON/ #JSON.sublime-syntax#comment
+#<- - meta.expect-include - meta.expect-include-list-or-content - meta.expect-include-list
 #                             ^^ comment
     - include: scope:source.regexp.oniguruma#base-group-extended
+#<- - meta.expect-include - meta.expect-include-list-or-content - meta.expect-include-list
 #              ^^^^^^ support.type.include.sublime-syntax
 #                   ^ punctuation.definition.scope-include.sublime-syntax
 #                                           ^ punctuation.separator.context-name.sublime-syntax - comment
 #                                            ^^^^^^^^^^^^^^^^^^^ variable.other.sublime-syntax
     - push: [main, Packages/JSON/JSON.sublime-syntax#comment]
+#<- - meta.expect-include - meta.expect-include-list-or-content - meta.expect-include-list
 #     ^^^^ string.unquoted.plain.out.yaml keyword.control.flow.push.sublime-syntax
 #           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.include-list meta.flow-sequence.yaml
 #            ^^^^ meta.include.sublime-syntax string
 #                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.include.sublime-syntax string
       set: Packages/JSON/JSON.sublime-syntax#comment
+#    ^ - meta.expect-include - meta.expect-include-list-or-content - meta.expect-include-list
 #     ^^^ string.unquoted.plain.out.yaml keyword.control.flow.push.sublime-syntax
 #          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.include.sublime-syntax string
     - set: Packages/JSON/JSON.sublime-syntax XX#comment
+#<- - meta.expect-include - meta.expect-include-list-or-content - meta.expect-include-list
 #          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string - meta.include
 
     - comment: this is a comment
@@ -230,6 +240,7 @@ contexts:
 #     ^^^^^ string.unquoted.plain.out.yaml keyword.operator.include.sublime-syntax
 #            ^^^^^ support.type.include.sublime-syntax
     - embed_scope: meta.embedded.source.test
+#<- - meta.expect-include - meta.expect-include-list-or-content - meta.expect-include-list
 #     ^^^^^^^^^^^ storage.type.scope-name.sublime-syntax
 #                  ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.scope.sublime-syntax string.unquoted.plain.out.yaml
     - escape: foo(.)bar
@@ -270,11 +281,21 @@ contexts: !mytag
 #       ^ meta.expect-include-list-or-content punctuation.definition.block.sequence.item.yaml
 
     - match: foo
+#<- - meta.expect-include - meta.expect-include-list-or-content - meta.expect-include-list
       push:   # comment
         -
 #       ^ meta.expect-include-list-or-content punctuation.definition.block.sequence.item.yaml
 
     - match: foo
+      push:   # comment
+        -
+    - match: foo
+#<- - meta.expect-include - meta.expect-include-list-or-content - meta.expect-include-list
+      push:   # comment
+        - context-name
+
+    - match: foo
+#<- - meta.expect-include - meta.expect-include-list-or-content - meta.expect-include-list
       push:
         - match
 #^^^^^^^^^^^^^^^ meta.expect-include-list-or-content
@@ -303,6 +324,7 @@ contexts: !mytag
 #       ^ punctuation.definition.block.sequence.item.yaml
 #         ^^^^^^^^^^^ invalid.illegal.include.sublime-syntax
           scope: invalid
+#<- - meta.include-list.sublime-syntax - meta.include
 #         ^ string.unquoted.plain.out.yaml storage.type.scope-name.sublime-syntax
 
     - match: foo
@@ -313,6 +335,7 @@ contexts: !mytag
   #       ^^^^^^^^^^^^^^^^^ - meta.expect-include-list-or-content - meta.expect-include-list - meta.include-list
 
     - match: foo
+#<- - meta.include-list.sublime-syntax - meta.include
 #   ^ meta.block.contexts.sublime-syntax punctuation.definition.block.sequence.item.yaml
 #     ^^^^^ meta.block.contexts.sublime-syntax string.unquoted.plain.out.yaml keyword.other.match.sublime-syntax
 

--- a/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
+++ b/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
@@ -158,12 +158,20 @@ contexts:
 #                   ^ punctuation.definition.scope-include.sublime-syntax
 #                                           ^ punctuation.separator.context-name.sublime-syntax - comment
 #                                            ^^^^^^^^^^^^^^^^^^^ variable.other.sublime-syntax
+
     - push: [main, Packages/JSON/JSON.sublime-syntax#comment]
 #<- - meta.expect-include - meta.expect-include-list-or-content - meta.expect-include-list
 #     ^^^^ string.unquoted.plain.out.yaml keyword.control.flow.push.sublime-syntax
+#           ^ punctuation.definition.array.begin.sublime-syntax
 #           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.include-list meta.flow-sequence.yaml
-#            ^^^^ meta.include.sublime-syntax string
+#            ^^^^ meta.include.sublime-syntax string variable
+#                ^ punctuation.separator.array-element.sublime-syntax
+#                 ^ - punctuation - string - support.module.file-path
 #                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.include.sublime-syntax string
+#                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ support.module.file-path.sublime-syntax
+#                                                   ^ punctuation.separator.context-name.sublime-syntax
+#                                                    ^^^^^^^ variable.other.sublime-syntax
+#                                                           ^ punctuation.definition.array.end.sublime-syntax
       set: Packages/JSON/JSON.sublime-syntax#comment
 #    ^ - meta.expect-include - meta.expect-include-list-or-content - meta.expect-include-list
 #     ^^^ string.unquoted.plain.out.yaml keyword.control.flow.push.sublime-syntax

--- a/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
+++ b/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
@@ -265,18 +265,53 @@ contexts: !mytag
 #                 ^^^^ constant.language.boolean.yaml
 
     - match: foo
-#   ^ meta.block.contexts.sublime-syntax punctuation.definition.block.sequence.item.yaml
-#     ^^^^^ meta.block.contexts.sublime-syntax string.unquoted.plain.out.yaml keyword.other.match.sublime-syntax
       push:
-#     ^^^^ meta.block.contexts.sublime-syntax string.unquoted.plain.out.yaml keyword.control.flow.push.sublime-syntax
-        - context-name-3
-#       ^^^^^^^^^^^^^^^^^ meta.block.contexts.sublime-syntax meta.expect-include-list meta.include-list.sublime-syntax meta.flow-sequence.yaml
-#       ^ punctuation.definition.block.sequence.yaml
-#         ^^^^^^^^^^^^^^ meta.include.sublime-syntax string.unquoted.plain.out.yaml variable.other.sublime-syntax
-        - context-name-2
-#       ^^^^^^^^^^^^^^^^^ meta.block.contexts.sublime-syntax meta.expect-include-list meta.include-list.sublime-syntax meta.flow-sequence.yaml
-#       ^ punctuation.definition.block.sequence.yaml
-#         ^^^^^^^^^^^^^^ meta.include.sublime-syntax string.unquoted.plain.out.yaml variable.other.sublime-syntax
+        -
+#       ^ meta.expect-include-list-or-content punctuation.definition.block.sequence.item.yaml
+
+    - match: foo
+      push:   # comment
+        -
+#       ^ meta.expect-include-list-or-content punctuation.definition.block.sequence.item.yaml
+
+    - match: foo
+      push:
+        - match
+#^^^^^^^^^^^^^^^ meta.expect-include-list-or-content
+#       ^^ meta.include-list - meta.include
+#         ^^^^^ meta.include-list meta.include.sublime-syntax
+#              ^ meta.include-list.sublime-syntax - meta.include
+#       ^ punctuation.definition.block.sequence.item.yaml
+#         ^^^^^ string.unquoted.plain.out.yaml variable.other.sublime-syntax
+        - match
+#<- meta.include-list.sublime-syntax - meta.include - meta.expect-include-list-or-content
+#       ^^ meta.include-list.sublime-syntax - meta.include
+#         ^^^^^ meta.include-list meta.include.sublime-syntax
+#              ^ meta.include-list.sublime-syntax - meta.include
+#       ^ punctuation.definition.block.sequence.item.yaml
+#         ^^^^^ string.unquoted.plain.out.yaml variable.other.sublime-syntax
+        - scope:source.yaml
+#       ^^ meta.include-list.sublime-syntax - meta.include
+#         ^^^^^^^^^^^^^^^^^ meta.include-list meta.include.sublime-syntax
+#                          ^ meta.include-list.sublime-syntax - meta.include
+        - YAML.sublime-syntax#property
+#       ^^ meta.include-list.sublime-syntax - meta.include
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.include-list meta.include.sublime-syntax
+#                                     ^ meta.include-list.sublime-syntax - meta.include
+        - match: test
+#       ^^^^^^^^^^^^^^ meta.include-list.sublime-syntax - meta.include
+#       ^ punctuation.definition.block.sequence.item.yaml
+#         ^^^^^^^^^^^ invalid.illegal.include.sublime-syntax
+          scope: invalid
+#         ^ string.unquoted.plain.out.yaml storage.type.scope-name.sublime-syntax
+
+    - match: foo
+      push:
+        - meta_scope: meta
+  #<- meta.expect-include-list-or-content
+  #^^^^^^^ meta.expect-include-list-or-content - meta.expect-include-list - meta.include-list
+  #       ^^^^^^^^^^^^^^^^^ - meta.expect-include-list-or-content - meta.expect-include-list - meta.include-list
+
     - match: foo
 #   ^ meta.block.contexts.sublime-syntax punctuation.definition.block.sequence.item.yaml
 #     ^^^^^ meta.block.contexts.sublime-syntax string.unquoted.plain.out.yaml keyword.other.match.sublime-syntax

--- a/plugins_/syntax_dev.py
+++ b/plugins_/syntax_dev.py
@@ -132,7 +132,7 @@ def _build_completions(base_keys=(), dict_keys=(), list_keys=()):
         (("{0}\t{0}:".format(s), "%s:\n  " % s) for s in dict_keys),
         (("{0}\t{0}:".format(s), "%s:\n- " % s) for s in list_keys)
     )
-    return tuple(sorted(generator))
+    return sorted(generator)
 
 
 class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
@@ -159,10 +159,129 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
     def is_applicable(cls, settings):
         return settings.get('syntax') == syntax_paths.SYNTAX_DEF
 
+    @_inhibit_word_completions
+    def on_query_completions(self, prefix, locations):
+
+        def verify_scope(selector, offset=0):
+            """Verify scope for each location."""
+            return all(self.view.match_selector(point + offset, selector)
+                       for point in locations)
+
+        # None of our business
+        if not verify_scope("- comment - (source.regexp - keyword.other.variable)"):
+            return None
+
+        # Scope name completions based on our scope_data database
+        if verify_scope("meta.expect-scope, meta.scope", -1):
+            return self._complete_scope(prefix, locations)
+
+        # Auto-completion for include values using the 'contexts' keys and for
+        if verify_scope("meta.expect-include-list-or-content", -1):
+            return self._complete_keywords(prefix, locations) + \
+                   self._complete_contexts(prefix, locations)
+
+        # Auto-completion for include values using the 'contexts' keys
+        if verify_scope("meta.expect-include-list | meta.expect-include"
+                        " | meta.include | meta.include-list"):
+            return self._complete_contexts(prefix, locations)
+
+        # Auto-completion for variables in match patterns using 'variables' keys
+        if verify_scope("keyword.other.variable"):
+            return self._complete_variable()
+
+        # Standard completions for unmatched regions
+        return self._complete_keywords(prefix, locations)
+
     def _line_prefix(self, point):
         _, col = self.view.rowcol(point)
         line = self.view.substr(self.view.line(point))
         return line[:col]
+
+    def _complete_contexts(self, prefix, locations):
+        # Verify that we're not looking for an external include
+        for point in locations:
+            line_prefix = self._line_prefix(point)
+            real_prefix = re.search(r"[^,\[ ]*$", line_prefix).group(0)
+            if real_prefix.startswith("scope:") or "/" in real_prefix:
+                return []  # Don't show any completions here
+            elif real_prefix != prefix:
+                # print("Unexpected prefix mismatch: {} vs {}".format(real_prefix, prefix))
+                return []
+
+        context_names = (
+            self.view.substr(r)
+            for r in self.view.find_by_selector("entity.name.context")
+        )
+        return [(ctx + "\tcontext", ctx) for ctx in context_names]
+
+    def _complete_keywords(self, prefix, locations):
+
+        def verify_scope(selector, offset=0):
+            """Verify scope for each location."""
+            return all(self.view.match_selector(point + offset, selector)
+                       for point in locations)
+
+        prefixes = set()
+        for point in locations:
+            # Ensure that we are completing a key name everywhere
+            line_prefix = self._line_prefix(point)
+            real_prefix = re.sub(r"^ +(- +)?", " ", line_prefix)  # collapse leading whitespace
+            prefixes.add(real_prefix)
+
+        if len(prefixes) != 1:
+            return None
+        else:
+            real_prefix = next(iter(prefixes))
+
+        # (Supposedly) all keys start their own line
+        match = re.match(r"^(\s*)[\w-]*$", real_prefix)
+        if not match:
+            return None
+        elif not match.group(1):
+            return self.base_completions_root
+        elif verify_scope("meta.block.contexts"):
+            return self.base_completions_contexts
+        else:
+            return None
+
+    def _complete_scope(self, prefix, locations):
+        # Determine entire prefix
+        prefixes = set()
+        for point in locations:
+            *_, real_prefix = self._line_prefix(point).rpartition(" ")
+            prefixes.add(real_prefix)
+
+        if len(prefixes) > 1:
+            return None
+        else:
+            real_prefix = next(iter(prefixes))
+
+        # Tokenize the current selector
+        tokens = real_prefix.split(".")
+        if len(tokens) <= 1:
+            # No work to be done here, just return the heads
+            return COMPILED_HEADS.to_completion()
+
+        base_scope_completion = self._complete_base_scope(tokens[-1])
+        # Browse the nodes and their children
+        nodes = COMPILED_HEADS
+        for i, token in enumerate(tokens[:-1]):
+            node = nodes.find(token)
+            if not node:
+                status("`%s` not found in scope naming conventions" % '.'.join(tokens[:i + 1]))
+                break
+            nodes = node.children
+            if not nodes:
+                status("No nodes available in scope naming conventions after `%s`"
+                       % '.'.join(tokens[:-1]))
+                break
+        else:
+            # Offer to complete from conventions or base scope
+            return nodes.to_completion() + base_scope_completion
+
+        # Since we don't have anything to offer,
+        # just complete the base scope appendix/suffix.
+        return base_scope_completion
 
     def _complete_base_scope(self, last_token):
         regions = self.view.find_by_selector("meta.scope string - meta.block")
@@ -183,108 +302,12 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
 
         return [(base_suffix + "\tbase suffix", base_suffix)]
 
-    @_inhibit_word_completions
-    def on_query_completions(self, prefix, locations):
-
-        def verify_scope(selector, offset=0):
-            """Verify scope for each location."""
-            return all(self.view.match_selector(point + offset, selector)
-                       for point in locations)
-
-        # None of our business
-        if not verify_scope("- comment - (source.regexp - keyword.other.variable)"):
-            return None
-
-        # Scope name completions based on our scope_data database
-        elif verify_scope("meta.expect-scope, meta.scope", -1):
-
-            # Determine entire prefix
-            prefixes = set()
-            for point in locations:
-                *_, real_prefix = self._line_prefix(point).rpartition(" ")
-                prefixes.add(real_prefix)
-
-            if len(prefixes) > 1:
-                return None
-            else:
-                real_prefix = next(iter(prefixes))
-
-            # Tokenize the current selector
-            tokens = real_prefix.split(".")
-            if len(tokens) <= 1:
-                # No work to be done here, just return the heads
-                return COMPILED_HEADS.to_completion()
-
-            base_scope_completion = self._complete_base_scope(tokens[-1])
-            # Browse the nodes and their children
-            nodes = COMPILED_HEADS
-            for i, token in enumerate(tokens[:-1]):
-                node = nodes.find(token)
-                if not node:
-                    status("`%s` not found in scope naming conventions" % '.'.join(tokens[:i + 1]))
-                    break
-                nodes = node.children
-                if not nodes:
-                    status("No nodes available in scope naming conventions after `%s`"
-                           % '.'.join(tokens[:-1]))
-                    break
-            else:
-                # Offer to complete from conventions or base scope
-                return nodes.to_completion() + base_scope_completion
-
-            # Since we don't have anything to offer,
-            # just complete the base scope appendix/suffix.
-            return base_scope_completion
-
-        # Auto-completion for include values using the 'contexts' keys
-        elif verify_scope("meta.expect-include-list | meta.expect-include"
-                          " | meta.include | meta.include-list"):
-            # Verify that we're not looking for an external include
-            for point in locations:
-                line_prefix = self._line_prefix(point)
-                real_prefix = re.search(r"[^,\[ ]*$", line_prefix).group(0)
-                if real_prefix.startswith("scope:") or "/" in real_prefix:
-                    return []  # Don't show any completions here
-                elif real_prefix != prefix:
-                    # print("Unexpected prefix mismatch: {} vs {}".format(real_prefix, prefix))
-                    return []
-
-            context_names = [self.view.substr(r)
-                             for r in self.view.find_by_selector("entity.name.context")]
-
-            return [(ctx + "\tcontext", ctx) for ctx in context_names]
-
-        # Auto-completion for variables in match patterns using 'variables' keys
-        elif verify_scope("keyword.other.variable"):
-            variable_names = [self.view.substr(r)
-                              for r in self.view.find_by_selector("entity.name.constant")]
-
-            return [(var + "\tvariable", var) for var in variable_names]
-
-        # Standard completions for unmatched regions
-        else:
-            prefixes = set()
-            for point in locations:
-                # Ensure that we are completing a key name everywhere
-                line_prefix = self._line_prefix(point)
-                real_prefix = re.sub(r"^ +(- +)?", " ", line_prefix)  # collapse leading whitespace
-                prefixes.add(real_prefix)
-
-            if len(prefixes) != 1:
-                return None
-            else:
-                real_prefix = next(iter(prefixes))
-
-            # (Supposedly) all keys start their own line
-            match = re.match(r"^(\s*)[\w-]*$", real_prefix)
-            if not match:
-                return None
-            elif not match.group(1):
-                return self.base_completions_root
-            elif verify_scope("meta.block.contexts"):
-                return self.base_completions_contexts
-            else:
-                return None
+    def _complete_variable(self):
+        variable_names = (
+            self.view.substr(r)
+            for r in self.view.find_by_selector("entity.name.constant")
+        )
+        return [(var + "\tvariable", var) for var in variable_names]
 
 
 class PackagedevCommitScopeCompletionCommand(sublime_plugin.TextCommand):

--- a/plugins_/syntax_dev.py
+++ b/plugins_/syntax_dev.py
@@ -156,6 +156,10 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
     base_suffix = None
 
     @classmethod
+    def applies_to_primary_view_only(cls):
+        return False
+
+    @classmethod
     def is_applicable(cls, settings):
         return settings.get('syntax') == syntax_paths.SYNTAX_DEF
 

--- a/plugins_/syntax_dev.py
+++ b/plugins_/syntax_dev.py
@@ -177,27 +177,27 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
 
         # Auto-completion for include values using the 'contexts' keys and for
         if verify_scope("meta.expect-include-list-or-content", -1):
-            return self._complete_keywords(prefix, locations) + \
-                   self._complete_contexts(prefix, locations)
+            return self._complete_keyword(prefix, locations) + \
+                self._complete_context(prefix, locations)
 
         # Auto-completion for include values using the 'contexts' keys
         if verify_scope("meta.expect-include-list | meta.expect-include"
-                        " | meta.include | meta.include-list"):
-            return self._complete_contexts(prefix, locations)
+                        " | meta.include | meta.include-list", -1):
+            return self._complete_context(prefix, locations)
 
         # Auto-completion for variables in match patterns using 'variables' keys
         if verify_scope("keyword.other.variable"):
             return self._complete_variable()
 
         # Standard completions for unmatched regions
-        return self._complete_keywords(prefix, locations)
+        return self._complete_keyword(prefix, locations)
 
     def _line_prefix(self, point):
         _, col = self.view.rowcol(point)
         line = self.view.substr(self.view.line(point))
         return line[:col]
 
-    def _complete_contexts(self, prefix, locations):
+    def _complete_context(self, prefix, locations):
         # Verify that we're not looking for an external include
         for point in locations:
             line_prefix = self._line_prefix(point)
@@ -214,7 +214,7 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
         )
         return [(ctx + "\tcontext", ctx) for ctx in context_names]
 
-    def _complete_keywords(self, prefix, locations):
+    def _complete_keyword(self, prefix, locations):
 
         def verify_scope(selector, offset=0):
             """Verify scope for each location."""


### PR DESCRIPTION
Fixes #201

This commit fixes an issue with multi-push/multi-set contexts not being scoped as include-list, if the sequence spans multiple lines.