### PR TITLE
Add some input helpers for sublime-syntax files

### DIFF
--- a/Package/Default.sublime-keymap
+++ b/Package/Default.sublime-keymap
@@ -22,6 +22,28 @@
             { "key": "selector", "operator": "equal", "operand": "meta.scope.sublime-syntax" }
         ]
     },
+    {   // auto-insert space and trigger auto completion after hyphon (rules)
+        "keys": ["-"], "command": "run_macro_file", "args": {"file": "res://Packages/PackageDev/Package/Sublime Text Syntax Definition/Add Syntax Rule.sublime-macro"}, "context": [
+            { "key": "preceding_text", "operator": "regex_match", "operand": "^\\s*$", "match_all": true },
+            { "key": "following_text", "operator": "regex_match", "operand": "^$" },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "selector", "operand": "source.yaml.sublime.syntax" },
+        ]
+    },
+    {   // auto-insert newline after double-colon (contexts)
+        "keys": [":"], "command": "insert", "args": { "characters": ":\n" }, "context": [
+            { "key": "preceding_text", "operator": "regex_match", "operand": "^ {0,2}[^\\s:]+$", "match_all": true },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "selector", "operand": "source.yaml.sublime.syntax" },
+        ]
+    },
+    {   // auto-insert space after double-colon (rules)
+        "keys": [":"], "command": "insert", "args": { "characters": ": " }, "context": [
+            { "key": "preceding_text", "operator": "regex_match", "operand": "^ {4,}(- *)?[^\\s:]+$", "match_all": true },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "selector", "operand": "source.yaml.sublime.syntax" },
+        ]
+    },
     /* end of syntax_dev keys */
 
     /* start of syntax_test_dev keys */

--- a/Package/Sublime Text Syntax Definition/Add Syntax Rule.sublime-macro
+++ b/Package/Sublime Text Syntax Definition/Add Syntax Rule.sublime-macro
@@ -1,0 +1,4 @@
+[
+    {"command": "insert", "args": {"characters": "- "}},
+    {"command": "auto_complete"}
+]

--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-settings
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-settings
@@ -11,5 +11,6 @@
     "auto_complete_selector": "source - comment - (source.regexp - keyword.other.variable)",
     "tab_size": 2,
     "translate_tabs_to_spaces": true,
+    "trim_trailing_white_space_on_save": true,
     "word_separators": "./\\()\"':,.;<>~!@#$%^&*|+=[]{}`~?" // default without '-'
 }


### PR DESCRIPTION
This commit adds some key bindings to:

1. auto-insert a newline, when typing a `:` after a context key. Context keys are recognized by being indented by at most two characters and not starting with `- `.
2. auto-insert a space after the first typed `:` in a line. This rule applies to situations when rules are inserted manually (not by auto-completion) or correcting them.
3. auto-insert space and trigger auto-completion, when typing the first `-` in a line, which indicates a new rule to be added. Up to this commit typing `-` directly triggers auto-completion as `-` was removed from word-separators. Committing the completion results in malformed yaml (e.g. -match: '').

Furthermore this commit adds a syntax-specific setting to ensure to trim trailing spaces, if the sublime-syntax file is saved.