### PR TITLE
Add contexts and variable to syntax reference list

### DIFF
--- a/Package/Sublime Text Syntax Definition/References - Context.tmPreferences
+++ b/Package/Sublime Text Syntax Definition/References - Context.tmPreferences
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>source.yaml.sublime.syntax meta.include variable.other</string>
+    <key>settings</key>
+    <dict>
+        <key>showInIndexedReferenceList</key>
+        <integer>1</integer>
+    </dict>
+</dict>
+</plist>

--- a/Package/Sublime Text Syntax Definition/References - Variable.tmPreferences
+++ b/Package/Sublime Text Syntax Definition/References - Variable.tmPreferences
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>source.yaml.sublime.syntax keyword.other.variable variable.other</string>
+    <key>settings</key>
+    <dict>
+        <key>showInIndexedReferenceList</key>
+        <integer>1</integer>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
This commit prepares PackageDev to correctly show all references of `contexts` and `variables` in the Goto Definition Popup in case https://github.com/SublimeTextIssues/Core/issues/2546 gets fixed some day.

This allows navigation between the definition of contexts/variables and all usages.