### PR TITLE
Add `first_line_match` to auto-completions in sublime-syntax

### DIFF
--- a/plugins_/syntax_dev.py
+++ b/plugins_/syntax_dev.py
@@ -138,7 +138,7 @@ def _build_completions(base_keys=(), dict_keys=(), list_keys=()):
 class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
 
     base_completions_root = _build_completions(
-        base_keys=('scope', 'name'),
+        base_keys=('name', 'scope', 'first_line_match'),
         dict_keys=('variables', 'contexts'),
         list_keys=('file_extensions',),
     )


### PR DESCRIPTION
This commit adds the `first_line_match` keyword to the list of base_keys to complete in root level of sublime-syntax files.