### PR TITLE
Revert "Fix context completions in multi-line push rules"

### DIFF
--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
@@ -335,8 +335,14 @@ contexts:
         - include: comment
         - include: yaml-block-sequence
         # first item after push/set looks like an included context
-        - match: ^([ ]+)(?=-\s*(?:{{plain_scalar_but_not_block_key}}|\s*$))
-          set: include_list_content
+        - match: ^([ ]+)(?=-\s*{{plain_scalar_but_not_block_key}})
+          set:
+            - meta_content_scope: meta.expect-include-list-or-content meta.include-list.sublime-syntax
+            - include: include_list_content
+            - match: ^(?=([ ]+)-)
+              set:
+                - meta_scope: meta.include-list.sublime-syntax
+                - include: include_list_content
         # limit context to the current line
         - match: $|(?=\S)
           pop: true
@@ -344,7 +350,6 @@ contexts:
       set: expect_include
 
   include_list_content:
-    - meta_content_scope: meta.include-list.sublime-syntax
     - include: comment
     - include: include
     - include: yaml-block-sequence

--- a/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
+++ b/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
@@ -286,13 +286,13 @@ contexts: !mytag
     - match: foo
       push:
         -
-#       ^ meta.include-list punctuation.definition.block.sequence.item.yaml
+#       ^ meta.expect-include-list-or-content punctuation.definition.block.sequence.item.yaml
 
     - match: foo
 #<- - meta.expect-include - meta.expect-include-list-or-content - meta.expect-include-list
       push:   # comment
         -
-#       ^ meta.include-list punctuation.definition.block.sequence.item.yaml
+#       ^ meta.expect-include-list-or-content punctuation.definition.block.sequence.item.yaml
 
     - match: foo
       push:   # comment
@@ -306,7 +306,7 @@ contexts: !mytag
 #<- - meta.expect-include - meta.expect-include-list-or-content - meta.expect-include-list
       push:
         - match
-#^^^^^^^ meta.expect-include-list-or-content
+#^^^^^^^^^^^^^^^ meta.expect-include-list-or-content
 #       ^^ meta.include-list - meta.include
 #         ^^^^^ meta.include-list meta.include.sublime-syntax
 #              ^ meta.include-list.sublime-syntax - meta.include


### PR DESCRIPTION
This reverts commit 832c2cfa16f042c8bc4fcaaa58ed6857bf3091d8.

This commit probposes to revert 832c2c as it breaks command completions in the first line after a push/set statement.

The first line after a push/set can either be
- the start of a list of included contexts
- or it can contain normal commands like `- match`.

Hence auto-completion must suggest the merged list of available contexts and the normal command completions if the cursor is in the first line.

This does not work in v3.2.2 due to the mentioned commit.

We only see context completions now.