### PR TITLE
Refine input helpers for sublime-syntax

### DIFF
--- a/Package/Default.sublime-keymap
+++ b/Package/Default.sublime-keymap
@@ -30,18 +30,25 @@
             { "key": "selector", "operand": "source.yaml.sublime.syntax" },
         ]
     },
+    {   // auto-insert space after double-colon (variables)
+        "keys": [":"], "command": "insert", "args": { "characters": ": " }, "context": [
+            { "key": "preceding_text", "operator": "regex_match", "operand": "^ *[^\\s:]+$", "match_all": true },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "selector", "operand": "meta.block.variables.sublime-syntax" },
+        ]
+    },
     {   // auto-insert space after double-colon (rules)
         "keys": [":"], "command": "insert", "args": { "characters": ": " }, "context": [
             { "key": "preceding_text", "operator": "regex_match", "operand": "^ {4,}(- *)?[^\\s:]+$", "match_all": true },
             { "key": "selection_empty", "match_all": true },
-            { "key": "selector", "operand": "source.yaml.sublime.syntax" },
+            { "key": "selector", "operand": "meta.block.contexts.sublime-syntax" },
         ]
     },
     {   // auto-insert newline after double-colon (contexts) and 'captures'
         "keys": [":"], "command": "insert", "args": { "characters": ":\n" }, "context": [
             { "key": "preceding_text", "operator": "regex_match", "operand": "^ {0,2}[^\\s:]+$|^ {4,}(- *)?(captures)+$", "match_all": true },
             { "key": "selection_empty", "match_all": true },
-            { "key": "selector", "operand": "source.yaml.sublime.syntax" },
+            { "key": "selector", "operand": "meta.block.contexts.sublime-syntax" },
         ]
     },
     /* end of syntax_dev keys */


### PR DESCRIPTION
After some further days of working with, I found some edge cases with
my recently proposed key bindings.

1. Adding a new-line after a `:` is not a good idea in the `variables`
   context. Therefore I'd suggest to limit this function to `contexts`.
   The only left key it might be useful with is the `file_extensions`
   key. Not sure if it makes sense to add it as well.

2. The other way round, adding a space after the first `:` would make
   sense in the `variables` context, if it does not yet exist.