### PR TITLE
Add support for anonymous syntax-context includes

### DIFF
--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
@@ -317,6 +317,7 @@ contexts:
     - meta_content_scope: meta.expect-include-list
     - include: comment
     - include: yaml-tags-anchors
+    # array-like include list
     - match: \[
       scope: punctuation.definition.array.begin.sublime-syntax
       set:
@@ -329,17 +330,23 @@ contexts:
         - include: comment
         - include: yaml-tags-anchors
         - include: include
+    # multi-line include list
     - match: ^
       set:
         - meta_scope: meta.expect-include-list-or-content
         - include: comment
         - include: yaml-block-sequence
+        - include: include_anonymous
         # first item after push/set looks like an included context
-        # maintain the 'expect' context to provide completions for both (context references and keys)
+        # -> maybe include, maybe incomplete key
+        # -> provide completions for both (context references and keys)
         - match: ^([ ]+)(?=-\s*{{plain_scalar_but_not_block_key}})
           set:
-            - meta_content_scope: meta.expect-include-list-or-content meta.include-list.sublime-syntax
+            - meta_content_scope: meta.include-list-or-content.sublime-syntax
             - include: include_list_content
+            # if the first line contains a context reference
+            # -> provide completions for context references only,
+            #    beginning from the second line
             - match: ^(?=([ ]+)-)
               set:
                 - meta_scope: meta.include-list.sublime-syntax
@@ -347,6 +354,7 @@ contexts:
         # limit context to the current line
         - match: $|(?=\S)
           pop: true
+    # maybe single include
     - match: (?=\S)
       set: expect_include
 
@@ -354,11 +362,23 @@ contexts:
     - include: comment
     - include: include
     - include: yaml-block-sequence
+    - include: include_anonymous
     # pop off at none-empty line with different indention than first include item
     - match: ^(?!(\s*$|\1-))
       pop: true
     - match: \S.+$
       scope: invalid.illegal.include.sublime-syntax
+
+  include_anonymous:
+    # a line with two (or more) hyphons after each other indicates the start
+    # of an anonymous context block embedded into an include list
+    - match: ^([ ]+)(?=- -)
+      push:
+        - clear_scopes: 1  # remove include-list... meta scopes
+        - meta_content_scope: meta.anonymous-context.sublime-syntax
+        - include: contexts_block
+        - match: ^(?!(\s*$|\1 +))
+          pop: true
 
   include:
     - match: '{{plain_scalar_but_not_block_key}}'

--- a/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
+++ b/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
@@ -306,14 +306,14 @@ contexts: !mytag
 #<- - meta.expect-include - meta.expect-include-list-or-content - meta.expect-include-list
       push:
         - match
-#^^^^^^^^^^^^^^^ meta.expect-include-list-or-content
-#       ^^ meta.include-list - meta.include
-#         ^^^^^ meta.include-list meta.include.sublime-syntax
-#              ^ meta.include-list.sublime-syntax - meta.include
+#^^^^^^^ meta.expect-include-list-or-content
+#       ^^ meta.include-list-or-content - meta.expect-include-list-or-content - meta.include
+#         ^^^^^ meta.include-list-or-content meta.include.sublime-syntax - meta.expect-include-list-or-content
+#              ^ meta.include-list-or-content.sublime-syntax - meta.expect-include-list-or-content - meta.include
 #       ^ punctuation.definition.block.sequence.item.yaml
 #         ^^^^^ string.unquoted.plain.out.yaml variable.other.sublime-syntax
         - match
-#<- meta.include-list.sublime-syntax - meta.include - meta.expect-include-list-or-content
+#<- meta.include-list.sublime-syntax - meta.include - meta.expect-include-list-or-content - meta.include-list-or-content
 #       ^^ meta.include-list.sublime-syntax - meta.include
 #         ^^^^^ meta.include-list meta.include.sublime-syntax
 #              ^ meta.include-list.sublime-syntax - meta.include
@@ -334,6 +334,48 @@ contexts: !mytag
           scope: invalid
 #<- - meta.include-list.sublime-syntax - meta.include
 #         ^ string.unquoted.plain.out.yaml storage.type.scope-name.sublime-syntax
+
+    - match: foo
+      push:
+        - - meta_scope: meta
+#      ^ - meta.anonymous-context
+#       ^^^^^^^^^^^^^^^^^^^^^ meta.anonymous-context.sublime-syntax
+#       ^ punctuation.definition.block.sequence.item.yaml
+#         ^ punctuation.definition.block.sequence.item.yaml
+#           ^^^^^^^^^^ storage.type.scope-name.meta.sublime-syntax
+          - include: context
+#        ^^^^^^^^^^^^^^^^^^^^ meta.anonymous-context.sublime-syntax
+#         ^ punctuation.definition.block.sequence.item.yaml
+#           ^^^^^^^ keyword.operator.include.sublime-syntax
+        - context-1
+#<- - meta.anonymous-context
+#      ^ meta.expect-include-list-or-content
+#       ^^ meta.include-list-or-content.sublime-syntax
+#         ^^^^^^^^^ meta.include-list-or-content.sublime-syntax meta.include.sublime-syntax
+#       ^ punctuation.definition.block.sequence.item.yaml
+#         ^^^^^^^^^ variable.other.sublime-syntax
+        - - meta_scope: meta
+#      ^ - meta.anonymous-context
+#       ^^^^^^^^^^^^^^^^^^^^^ meta.anonymous-context.sublime-syntax
+#       ^ punctuation.definition.block.sequence.item.yaml
+#         ^ punctuation.definition.block.sequence.item.yaml
+#           ^^^^^^^^^^ storage.type.scope-name.meta.sublime-syntax
+          - include: context
+#        ^^^^^^^^^^^^^^^^^^^^ meta.anonymous-context.sublime-syntax
+#         ^ punctuation.definition.block.sequence.item.yaml
+#           ^^^^^^^ keyword.operator.include.sublime-syntax
+        - context-2
+#<- - meta.anonymous-context
+#      ^^^ meta.include-list.sublime-syntax
+#         ^^^^^^^^^ meta.include-list.sublime-syntax meta.include.sublime-syntax
+#       ^ punctuation.definition.block.sequence.item.yaml
+#         ^^^^^^^^^ variable.other.sublime-syntax
+        - context-3
+#<- - meta.anonymous-context
+#      ^^^ meta.include-list.sublime-syntax
+#         ^^^^^^^^^ meta.include-list.sublime-syntax meta.include.sublime-syntax
+#       ^ punctuation.definition.block.sequence.item.yaml
+#         ^^^^^^^^^ variable.other.sublime-syntax
 
     - match: foo
       push:

--- a/plugins_/syntax_dev.py
+++ b/plugins_/syntax_dev.py
@@ -183,7 +183,8 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
             return self._complete_scope(prefix, locations)
 
         # Auto-completion for include values using the 'contexts' keys and for
-        if verify_scope("meta.expect-include-list-or-content", -1):
+        if verify_scope("meta.expect-include-list-or-content"
+                        " | meta.include-list-or-content", -1):
             return self._complete_keyword(prefix, locations) + \
                 self._complete_context(prefix, locations)
 
@@ -241,7 +242,7 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
             real_prefix = next(iter(prefixes))
 
         # (Supposedly) all keys start their own line
-        match = re.match(r"^(\s*)[\w-]*$", real_prefix)
+        match = re.match(r"^(\s*)[\w-]*.*$", real_prefix)
         if not match:
             return None
         elif not match.group(1):


### PR DESCRIPTION
The latest Lua.sublime-syntax contains include lists with anonymous contexts, which are not covered by the recent changes to support multi-line includes.

### Example

```YAML
- match: foo
  push:
    - - meta_scope: meta
      - match: bar
        scope: keyword
        pop: true
    - context-2
    - context 3
    - - match: baz
        pop: true
    - context-4
```

This commit adds the required changes to support these kinds of mixed include lists.

### anonymous contexts

If a `- -` is detected within a multi-line-include-list a new `include_anonymous` context is pushed to the stack. This prevents the `expect_include_list` context to be popped off too early, which would end the include-list. The `include_anonymous` keeps on stack as long as the indention is larger than the indention of the current include-list.

In order to prevent context references to be included into the completions as long as the `include_anonymous` is on stack, the `meta.expect-include...` and `meta.include-...` scopes need to be
cleared.

### meta-scope changes

As the `include_anonymous` is included several times, it can clear only a predefined number of meta scopes. That's why the `meta.expect-include-list-or-content` can't span the whole first line as indicator for context- and key-completions in conjunction with `meta.include-list.sublime-syntax`.

That's why, it is split into

- `meta.expect-include-list-or-content` from line start up to `-`
- `meta.include-list-or-content` for the rest of the line.

The selector in the `syntax_dev.py` was changed accordingly.

### logic changes

Another fix was required in `syntax_dev.py` to support normal keyword completions within the `include_anonymous` context as the second `-` needs to be ignored.