### PR TITLE
Theme: Add status bar VCS indicator elements

### DIFF
--- a/Package/Sublime Text Theme/Completions/Elements (in-string).sublime-completions
+++ b/Package/Sublime Text Theme/Completions/Elements (in-string).sublime-completions
@@ -79,5 +79,7 @@
         { "trigger": "title_label_control\telement", "contents": "title_label_control" },
         { "trigger": "tool_tip_control\telement", "contents": "tool_tip_control" },
         { "trigger": "tool_tip_label_control\telement", "contents": "tool_tip_label_control" },
+        { "trigger": "vcs_branch_icon\telement", "contents": "vcs_branch_icon" },
+        { "trigger": "vcs_changes_annotation\telement", "contents": "vcs_changes_annotation" },
     ]
 }


### PR DESCRIPTION
According to a recent forum post the following theme elements are now supported to style the new vcs status bar indicators.