### PR TITLE
Theme/Scheme: Variables can contain hyphens

### DIFF
--- a/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-settings
+++ b/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-settings
@@ -4,4 +4,6 @@
     [
         {"characters": ".", "selector": "meta.scope-selector.sublime"}
     ],
+    "trim_trailing_white_space_on_save": true,
+    "word_separators": "./\\()\"':,.;<>~!@#$%^&*|+=[]{}`~?" // default without '-'
 }

--- a/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-settings
+++ b/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-settings
@@ -4,6 +4,5 @@
     [
         {"characters": ".", "selector": "meta.scope-selector.sublime"}
     ],
-    "trim_trailing_white_space_on_save": true,
     "word_separators": "./\\()\"':,.;<>~!@#$%^&*|+=[]{}`~?" // default without '-'
 }

--- a/Package/Sublime Text Theme/Sublime Text Theme.sublime-settings
+++ b/Package/Sublime Text Theme/Sublime Text Theme.sublime-settings
@@ -1,4 +1,6 @@
 {
     "extensions": ["sublime-theme"],
     "auto_complete_selector": "- string - comment - constant | meta.main-key | meta.rule-key | meta.interpolation-key | meta.animation-key | meta.attributes-sequence - comment | meta.class-selector | meta.function-call.var meta.group",
+    "trim_trailing_white_space_on_save": true,
+    "word_separators": "./\\()\"':,.;<>~!@#$%^&*|+=[]{}`~?" // default without '-'
 }

--- a/Package/Sublime Text Theme/Sublime Text Theme.sublime-settings
+++ b/Package/Sublime Text Theme/Sublime Text Theme.sublime-settings
@@ -1,6 +1,5 @@
 {
     "extensions": ["sublime-theme"],
     "auto_complete_selector": "- string - comment - constant | meta.main-key | meta.rule-key | meta.interpolation-key | meta.animation-key | meta.attributes-sequence - comment | meta.class-selector | meta.function-call.var meta.group",
-    "trim_trailing_white_space_on_save": true,
     "word_separators": "./\\()\"':,.;<>~!@#$%^&*|+=[]{}`~?" // default without '-'
 }


### PR DESCRIPTION
The hyphen is removed from the list of word separators to fix goto definition/reference for variables, whose names contain them.