### PR TITLE
Theme/Scheme: Add symbol/reference lists for variables

### DIFF
--- a/Package/Sublime Text Color Scheme/References - Variable.tmPreferences
+++ b/Package/Sublime Text Color Scheme/References - Variable.tmPreferences
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string><![CDATA[meta.theme.sublime-color-scheme meta.function-call variable.other]]></string>
+    <key>settings</key>
+    <dict>
+        <key>showInIndexedReferenceList</key>
+        <integer>1</integer>
+    </dict>
+</dict>
+</plist>

--- a/Package/Sublime Text Theme/References - Variable.tmPreferences
+++ b/Package/Sublime Text Theme/References - Variable.tmPreferences
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string><![CDATA[meta.theme.sublime-theme meta.function-call variable.other]]></string>
+    <key>settings</key>
+    <dict>
+        <key>showInIndexedReferenceList</key>
+        <integer>1</integer>
+    </dict>
+</dict>
+</plist>

--- a/Package/Sublime Text Theme/Symbols - Class Selectors.tmPreferences
+++ b/Package/Sublime Text Theme/Symbols - Class Selectors.tmPreferences
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>name</key>
-    <string>Symbol List - Sublime Text Theme</string>
     <key>scope</key>
     <string><![CDATA[entity.name.class-selector.sublime-theme - meta.parent-mapping.sublime-theme]]></string>
     <key>settings</key>

--- a/Package/Sublime Text Theme/Symbols - Variable.tmPreferences
+++ b/Package/Sublime Text Theme/Symbols - Variable.tmPreferences
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string><![CDATA[entity.name.variable.sublime-theme]]></string>
+    <key>settings</key>
+    <dict>
+        <key>showInSymbolList</key>
+        <integer>1</integer>
+        <key>showInIndexedSymbolList</key>
+        <integer>1</integer>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
This commit enables Goto Definition/Goto Reference for variables in

- sublime-color-schemes
- sublime-themes