### PR TITLE
Theme: Fix CSS color support for tint_modifier

### DIFF
--- a/Package/Sublime Text Theme/Sublime Text Theme.sublime-syntax
+++ b/Package/Sublime Text Theme/Sublime Text Theme.sublime-syntax
@@ -25,6 +25,7 @@ variables:
       | color_scheme_tint(?:_2)?
       | color\d+
       | link_color # from Sublime Merge
+      | (?:accent_)?tint_modifier
     )
   integer_key: |-
     (?x:
@@ -49,9 +50,7 @@ variables:
     (?x:
         min_size
       | icon_spacing
-      | tint_modifier
       | shadow_offset
-      | accent_tint_modifier
     )
   float_key: |-
     (?x:

--- a/Package/Sublime Text Theme/syntax_test_newstyletheme.json
+++ b/Package/Sublime Text Theme/syntax_test_newstyletheme.json
@@ -81,6 +81,9 @@
 //           ^^^^^^^^^ meta.rule-key.string.sublime-theme string.quoted.double.json keyword.other.rule.sublime-theme
         },
         { // colors
+            "tint_modifier": "rgba(235, 237, 239, 0.1)",
+//           ^^^^^^^^^^^^^ meta.rule-key.color.sublime-theme string.quoted.double.json keyword.other.rule.sublime-theme
+//                            ^^^^ meta.function-call.css support.function.color.css
             "layer0.tint": "var(--background)"
 //          ^^^^^^^^^^^^^ meta.mapping.key.json meta.rule-key.color.sublime-theme string.quoted.double.json
 //           ^^^^^^^^^^^ keyword.other.rule.sublime-theme
@@ -147,7 +150,7 @@
 //           ^^^^^^^^ meta.rule-key.number.sublime-theme string.quoted.double.json keyword.other.rule.sublime-theme
 //                      ^^ invalid.illegal.expected-sequence.sublime
             "tint_modifier": [12, 11],
-//           ^^^^^^^^^^^^^ meta.rule-key.number.sublime-theme string.quoted.double.json keyword.other.rule.sublime-theme
+//           ^^^^^^^^^^^^^ meta.rule-key.color.sublime-theme string.quoted.double.json keyword.other.rule.sublime-theme
 //                            ^^ constant.numeric.json
             "random_key": null
 //          ^^^^^^^^^^^^ meta.rule-key.sublime-theme


### PR DESCRIPTION
ST 3179+ supports CSS colors in `tint_modifier` and `accent_tint_modifier` keys.