### PR TITLE
Theme/Scheme: Add builtin color completions

### DIFF
--- a/plugins_/color_scheme_dev.py
+++ b/plugins_/color_scheme_dev.py
@@ -32,6 +32,20 @@ SCHEME_TEMPLATE = """\
   ],
 }""".replace("  ", "\t")
 
+VARIABLES = [
+    ("--background\tbuiltin color", "--background"),
+    ("--foreground\tbuiltin color", "--foreground"),
+    ("--accent\tbuiltin color", "--accent"),
+    ("--bluish\tbuiltin color", "--bluish"),
+    ("--cyanish\tbuiltin color", "--cyanish"),
+    ("--greenish\tbuiltin color", "--greenish"),
+    ("--orangish\tbuiltin color", "--orangish"),
+    ("--pinkish\tbuiltin color", "--pinkish"),
+    ("--purplish\tbuiltin color", "--purplish"),
+    ("--redish\tbuiltin color", "--redish"),
+    ("--yellowish\tbuiltin color", "--yellowish"),
+]
+
 l = logging.getLogger(__name__)
 
 
@@ -74,7 +88,7 @@ class ColorSchemeCompletionsListener(sublime_plugin.ViewEventListener):
                                                       "entity.name.variable.sublime-theme")
         variables = set(self.view.substr(r) for r in variable_regions)
         l.debug("Found %d variables to complete: %r", len(variables), sorted(variables))
-        return sorted(("{}\tvariable".format(var), var) for var in variables)
+        return VARIABLES + sorted(("{}\tvariable".format(var), var) for var in variables)
 
     def _scope_prefix(self, locations):
         # Determine entire prefix


### PR DESCRIPTION
This commit adds all the `--...ish` like colors to the variable completions. The completions are implemented in the color_scheme_dev.py to create consistent results with all the locally defined variables and to work around an issue of the sublime-completions file format, which prevents triggers beginning with none-word characters.