### PR TITLE
Theme: Enable rule completions in the parent mapping

### DIFF
--- a/Package/Sublime Text Theme/Completions/Rule Keys.sublime-completions
+++ b/Package/Sublime Text Theme/Completions/Rule Keys.sublime-completions
@@ -1,5 +1,5 @@
 {
-    "scope": "meta.rule.sublime-theme - meta.rule.sublime-theme meta meta - string - comment",
+    "scope": "(meta.rule.sublime-theme - meta.rule.sublime-theme meta meta | meta.parent-mapping.sublime-theme - meta.parent-mapping.sublime-theme meta meta) - string - comment",
     "completions": [
         // selectors
         { "trigger": "class\tselector", "contents": "\"class\": \"$0\"," },


### PR DESCRIPTION
This commit enables rule completions in "parent" mappings:

      "parents": [
        {"class": "dialog", "attributes": ["file_light"]}
          ^^^^^ ^ here
      ],