### PR TITLE
Theme: Add more VCS status attributes

### DIFF
--- a/Package/Sublime Text Theme/Completions/Attributes (in-string).sublime-completions
+++ b/Package/Sublime Text Theme/Completions/Attributes (in-string).sublime-completions
@@ -22,11 +22,13 @@
         { "trigger": "highlighted\tattribute", "contents": "highlighted" },
         { "trigger": "left\tattribute", "contents": "left" },
         { "trigger": "right\tattribute", "contents": "right" },
+        { "trigger": "ignored\tattribute", "contents": "ignored" },
         { "trigger": "untracked\tattribute", "contents": "untracked" },
         { "trigger": "modified\tattribute", "contents": "modified" },
-        { "trigger": "staged\tattribute", "contents": "staged" },
+        { "trigger": "missing\tattribute", "contents": "missing" },
         { "trigger": "added\tattribute", "contents": "added" },
+        { "trigger": "staged\tattribute", "contents": "staged" },
+        { "trigger": "deleted\tattribute", "contents": "deleted" },
         { "trigger": "unmerged\tattribute", "contents": "unmerged" },
-        { "trigger": "ignored\tattribute", "contents": "ignored" },
     ]
 }

--- a/Package/Sublime Text Theme/Completions/Attributes.sublime-completions
+++ b/Package/Sublime Text Theme/Completions/Attributes.sublime-completions
@@ -22,11 +22,13 @@
         { "trigger": "highlighted\tattribute", "contents": "\"highlighted\"" },
         { "trigger": "left\tattribute", "contents": "\"left\"" },
         { "trigger": "right\tattribute", "contents": "\"right\"" },
+        { "trigger": "ignored\tattribute", "contents": "\"ignored\"" },
         { "trigger": "untracked\tattribute", "contents": "\"untracked\"" },
         { "trigger": "modified\tattribute", "contents": "\"modified\"" },
-        { "trigger": "staged\tattribute", "contents": "\"staged\"" },
+        { "trigger": "missing\tattribute", "contents": "\"missing\"" },
         { "trigger": "added\tattribute", "contents": "\"added\"" },
+        { "trigger": "staged\tattribute", "contents": "\"staged\"" },
+        { "trigger": "deleted\tattribute", "contents": "\"deleted\"" },
         { "trigger": "unmerged\tattribute", "contents": "\"unmerged\"" },
-        { "trigger": "ignored\tattribute", "contents": "\"ignored\"" },
     ]
 }

--- a/Package/Sublime Text Theme/Sublime Text Theme.sublime-syntax
+++ b/Package/Sublime Text Theme/Sublime Text Theme.sublime-syntax
@@ -84,7 +84,7 @@ variables:
       | pressed | confirm | highlighted # button_control
       | left | right # icon_button_control
       | h?scrollable # scroll_area_control
-      | untracked | modified | staged | added | unmerged | ignored # file_system_entry
+      | ignored | untracked | modified | missing | added | staged | deleted | unmerged # file_system_entry
     )
   platform: |-
     (?x: linux | osx | windows )


### PR DESCRIPTION
This commit

1. adds `missing` and `deleted` vcs status attribute values
2. sorts all values according to the theming guideline

see: https://www.sublimetext.com/docs/3/dev/themes.html -> file_system_entry -> attributes