### PR TITLE
Theme: This commit adds the 'case' property

### DIFF
--- a/Package/Sublime Text Theme/Completions/Rule Keys (in-string).sublime-completions
+++ b/Package/Sublime Text Theme/Completions/Rule Keys (in-string).sublime-completions
@@ -9,6 +9,7 @@
         { "trigger": "attributes\tselector", "contents": "attributes" },
 
         // strings
+        { "trigger": "case\tproperty", "contents": "case" },
         { "trigger": "font.face\tproperty", "contents": "font.face" },
 
         // colors

--- a/Package/Sublime Text Theme/Completions/Rule Keys.sublime-completions
+++ b/Package/Sublime Text Theme/Completions/Rule Keys.sublime-completions
@@ -8,7 +8,9 @@
         { "trigger": "platforms\tselector", "contents": "\"platforms\": [$0]," },
         { "trigger": "attributes\tselector", "contents": "\"attributes\": [\"$0\"]," },
 
+
         // strings
+        { "trigger": "case\tproperty", "contents": "\"case\": \"$0\"," },
         { "trigger": "font.face\tproperty", "contents": "\"font.face\": \"$0\"," },
 
         // colors

--- a/Package/Sublime Text Theme/Sublime Text Theme.sublime-syntax
+++ b/Package/Sublime Text Theme/Sublime Text Theme.sublime-syntax
@@ -9,7 +9,8 @@ scope: source.json.sublime.theme
 variables:
   string_key: |-
     (?x:
-      font\.face
+        case # sidebar heading
+      | font\.face
     )
   color_key: |-
     (?x:


### PR DESCRIPTION
The `case` property enables themes to modify the rendering of the side bar headings like `Folders` or `Open Files`.

It is implemented as string value by this commit.

As this property is basically an enumeration of "upper", "lower", "title", it should get its own meta scope and a value completion in the future.

The current implementation of the JSON/theme syntax mixture causes all additional meta scopes to be cleared from a string value. A new approach/implementation of string values is needed first to enable completions.