### PR TITLE
Theme: Add 'hidden-theme' extension

### DIFF
--- a/Package/Sublime Text Theme/Sublime Text Theme.sublime-syntax
+++ b/Package/Sublime Text Theme/Sublime Text Theme.sublime-syntax
@@ -4,6 +4,7 @@
 name: Sublime Text Theme (JSON)
 file_extensions:
   - sublime-theme
+  - hidden-theme
 scope: source.json.sublime.theme
 
 variables:


### PR DESCRIPTION
This commit accociates the `hidden-theme` extension with the `Sublime Text Theme` syntax. There is no such hidden theme out in the wild so far, but the naming follows the `Sublime Text Color Scheme` syntax which uses `hidden-color-scheme`