### PR TITLE
Syntax: Update a couple of completions

### DIFF
--- a/plugins_/lib/scope_data/data.py
+++ b/plugins_/lib/scope_data/data.py
@@ -56,8 +56,14 @@ DATA = """
             flow
             import
         declaration
-            extends
-            throws
+            function
+            class
+            struct
+            enum
+            union
+            trait
+            interface
+            impl
         operator
             assignment
             arithmetic
@@ -90,12 +96,16 @@ DATA = """
         union
         trait
         interface
+        impl
         type
         function
             parameters
             return-type
         namespace
         preprocessor
+        annotation
+            identifier
+            parameters
         path
         function-call
         block
@@ -107,15 +117,19 @@ DATA = """
         tag
         paragraph
         toc-list
+        string
+        interpolation
         sequence
         mapping
             key
             value
-        annotation
         set
 
     punctuation
         definition
+            annotation
+                begin
+                end
             string
                 begin
                 end
@@ -123,10 +137,15 @@ DATA = """
                 begin
                 end
             keyword
+                begin
+                end
             generic
                 begin
                 end
             placeholder
+                begin
+                end
+            variable
                 begin
                 end
         section
@@ -155,6 +174,7 @@ DATA = """
                 begin
                 end
         separator
+            continuation
             sequence
             mapping
                 key-value
@@ -171,6 +191,14 @@ DATA = """
 
     storage
         type
+            function
+            class
+            struct
+            enum
+            union
+            trait
+            interface
+            impl
         modifier
 
     string
@@ -200,4 +228,5 @@ DATA = """
         other
             constant
             member
+            readwrite
 """


### PR DESCRIPTION
This commit updates completions for sublime-syntax development according to the new scope naming guidelines, which are not yet covered by another PR.

see: https://www.sublimetext.com/docs/3/scope_naming.html#constant

Note: The keywords `extends` and `throws` are no longer part of the scope naming guideline. They are therefore removed from the completions.