### PR TITLE
Project: Fix Build Systems mapping

### DIFF
--- a/Package/Sublime Text Build System/Sublime Text Build System.sublime-syntax
+++ b/Package/Sublime Text Build System/Sublime Text Build System.sublime-syntax
@@ -59,6 +59,15 @@ contexts:
     - include: platform-key
     - include: in-dictionary-main-key
 
+  name-key:
+    - match: (")(name)(")
+      scope: meta.mapping.key.json meta.main-key.sublime-build string.quoted.double.json
+      captures:
+        1: punctuation.definition.string.begin.json
+        2: keyword.other.main.sublime-build
+        3: punctuation.definition.string.end.json
+      set: [expect-variant-name-string-value, expect-colon]
+
   platform-key:
     - match: (")(linux|osx|windows)(")
       scope: meta.mapping.key.json meta.main-key.sublime-build string.quoted.double.json
@@ -205,13 +214,7 @@ contexts:
     - include: target-key
     - include: exec-args-key
     - include: platform-key
-    - match: (")(name)(")
-      scope: meta.mapping.key.json meta.main-key.sublime-build string.quoted.double.json
-      captures:
-        1: punctuation.definition.string.begin.json
-        2: keyword.other.main.sublime-build
-        3: punctuation.definition.string.end.json
-      set: [expect-variant-name-string-value, expect-colon]
+    - include: name-key
     - include: in-dictionary-main-key
 
   expect-platform-mapping-value:

--- a/Package/Sublime Text Project/Completions/Build System Keys (in-string).sublime-completions
+++ b/Package/Sublime Text Project/Completions/Build System Keys (in-string).sublime-completions
@@ -1,0 +1,9 @@
+{
+    "scope": "meta.project.build.sublime-project meta.main-key.sublime-build - meta.sequence meta.mapping meta.mapping - comment",
+    "completions": [
+        { "trigger": "name\tmain key", "contents": "name" },
+        { "trigger": "selector\tmain key", "contents": "selector" },
+        { "trigger": "variants\tmain key", "contents": "variants" },
+        { "trigger": "keyfiles\tmain key", "contents": "keyfiles" },
+    ]
+}

--- a/Package/Sublime Text Project/Completions/Build System Keys.sublime-completions
+++ b/Package/Sublime Text Project/Completions/Build System Keys.sublime-completions
@@ -1,0 +1,9 @@
+{
+    "scope": "meta.project.build.sublime-project -  meta.sequence meta.mapping meta.mapping - string - comment",
+    "completions": [
+        { "trigger": "name\tmain key", "contents": "\"name\": \"$1\"," },
+        { "trigger": "selector\tmain key", "contents": "\"selector\": \"$1\",$0" },
+        { "trigger": "variants\tmain key", "contents": "\"variants\": [\n\t$0\n]," },
+        { "trigger": "keyfiles\tmain key", "contents": "\"keyfiles\": [\"$0\"]," },
+    ],
+}

--- a/Package/Sublime Text Project/Sublime Text Project.sublime-syntax
+++ b/Package/Sublime Text Project/Sublime Text Project.sublime-syntax
@@ -165,7 +165,39 @@ contexts:
         - include: string-escape
 
   expect-build-systems-sequence-value:
-    - include: Sublime Text Build System.sublime-syntax#expect-variants-sequence-value
+    - match: (?=\[)
+      set: [mapping-value-meta, build-systems-sequence-pop]
+    - include: expect-sequence-rest
+
+  build-systems-sequence-pop:
+    - match: \[
+      scope: punctuation.section.sequence.begin.json
+      set:
+        - meta_scope: meta.project.build.collection.sublime-project meta.sequence.json
+        - match: \]
+          scope: punctuation.section.sequence.end.json
+          pop: true
+        - match: (?=\{)
+          push: [in-sequence-expect-comma, build-system-mapping-pop]
+        - include: comments
+        - match: \S
+          scope: invalid.illegal.expected-mapping.sublime-build
+
+  build-system-mapping-pop:
+    - match: \{
+      scope: punctuation.section.mapping.begin.json
+      set:
+        - meta_scope: meta.project.build.sublime-project meta.build.collection.sublime-build meta.mapping.json
+        - match: \}
+          scope: punctuation.section.mapping.end.json
+          pop: true
+        - match: (?=")
+          push: [in-mapping-expect-comma, in-build-system-main-key]
+        - include: expect-key-rest
+
+  in-build-system-main-key:
+    - include: Sublime Text Build System.sublime-syntax#name-key
+    - include: Sublime Text Build System.sublime-syntax#main-key
 
   expect-settings-mapping-value:
     - match: (?=\{)

--- a/Package/Sublime Text Project/syntax_test_project.json
+++ b/Package/Sublime Text Project/syntax_test_project.json
@@ -45,11 +45,22 @@
     "build_systems": true [
 //   ^^^^^^^^^^^^^ meta.mapping.key.json meta.main-key.sublime-project string.quoted.double.json keyword.other.main.sublime-project
 //                   ^^^^ invalid.illegal.expected-sequence.sublime
-//                        ^  meta.mapping.value.json meta.variants.collection.sublime-build meta.sequence.json punctuation.section.sequence.begin.json
+//                        ^  meta.mapping.value.json meta.project.build.collection.sublime-project meta.sequence.json punctuation.section.sequence.begin.json
         {
             "name": "Test Build",
+//           ^^^^ meta.main-key.sublime-build string.quoted.double.json keyword.other.main.sublime-build
             "shell_cmd": "sh $file",
 //                            ^^^^ meta.placeholder-name.sublime-build constant.other.placeholder.sublime-build
+            "selector": "source.html",
+//           ^^^^^^^^ meta.main-key.sublime-build string.quoted.double.json keyword.other.main.sublime-build
+            "variants": [
+                {
+                    "name": "Variant",
+//                   ^^^^ meta.variant.sublime-build meta.mapping.key.json meta.main-key.sublime-build string.quoted.double.json keyword.other.main.sublime-build
+                    "selector": "invalid",
+//                   ^^^^^^^^ meta.main-key.sublime-build string.quoted.double.json - keyword.other.main.sublime-build
+                },
+            ],
         },
     ],
 


### PR DESCRIPTION
The `build_systems` dictionary in a sublime-project file does not
contain a build system variant, but a list of full featured build
systems.

This means `selector` is a valid key. Additionally the `name` key is
used to identify the build system.

Note:

  The completions selectors might need to be tweaked a bit as some
  glitches were encountered. main keys are suggested within the `cmd`
  value part for instance. Looks like another issue.