### PR TITLE
Update scope used in Keymap syntax to follow conventions

### DIFF
--- a/Package/Sublime Text Keymap/Sublime Text Keymap.sublime-syntax
+++ b/Package/Sublime Text Keymap/Sublime Text Keymap.sublime-syntax
@@ -120,14 +120,14 @@ contexts:
         - match: (")(<character>)(")
           scope: string.quoted.double.json
           captures:
-            1: punctuation.definition.string.start.json
+            1: punctuation.definition.string.begin.json
             2: meta.key-chord.sublime-keymap support.constant.key.captured.sublime-keymap
             3: punctuation.definition.string.end.json
           push: in-sequence-expect-comma
         - match: (")((\\.)|([^"]))(")
           scope: string.quoted.double.json
           captures:
-            1: punctuation.definition.string.start.json
+            1: punctuation.definition.string.begin.json
             2: meta.key-chord.sublime-keymap
             3: constant.character.escape.json
             4: constant.character.key.literal.sublime-keymap


### PR DESCRIPTION
Per the [scope naming conventions for `string.`](https://www.sublimetext.com/docs/3/scope_naming.html#string), open quotes should use the scope `punctuation.definition.string.begin` instead of `punctuation.definition.string.start`.