### PR TITLE
[Snippets] Fix selector after &amp; operator

### DIFF
--- a/Package/Scope Selector.sublime-syntax
+++ b/Package/Scope Selector.sublime-syntax
@@ -25,6 +25,9 @@ contexts:
           pop: true
         - match: '\s+\('
           scope: invalid.illegal.operator-required-between-scope-and-group.scope-selector
+        - match: '\s+(?=\w)'
+          scope: keyword.operator.right.scope-selector
+          pop: true
         - match: ''
           pop: true
     - match: '-'
@@ -44,5 +47,3 @@ contexts:
             - match: '\s*'
               pop: true
         - include: base
-    - match: ' '
-      scope: keyword.operator.right.scope-selector

--- a/Package/Scope Selector.sublime-syntax
+++ b/Package/Scope Selector.sublime-syntax
@@ -27,22 +27,17 @@ contexts:
           scope: invalid.illegal.operator-required-between-scope-and-group.scope-selector
         - match: ''
           pop: true
-    - match: '\s*(-)\s*'
-      captures:
-        1: keyword.operator.without.scope-selector
-    - match: '\s*(&)\s*'
-      captures:
-        1: keyword.operator.with.scope-selector
-    - match: '\s*([,|])\s*'
-      captures:
-        1: keyword.operator.or.scope-selector
-    - match: '\s*(\()\s*'
-      captures:
-        1: punctuation.section.group.begin.scope-selector
+    - match: '-'
+      scope: keyword.operator.without.scope-selector
+    - match: '&'
+      scope: keyword.operator.with.scope-selector
+    - match: '[,|]'
+      scope: keyword.operator.or.scope-selector
+    - match: '\('
+      scope: punctuation.section.group.begin.scope-selector
       push:
-        - match: '\s*(\))'
-          captures:
-            1: punctuation.section.group.end.scope-selector
+        - match: '\)'
+          scope: punctuation.section.group.end.scope-selector
           set:
             - match: '(\s*{{scope_segment}}|\.)+'
               scope: invalid.illegal.operator-required-after-group.scope-selector

--- a/Package/Sublime Text Snippet/Sublime Text Snippet.sublime-syntax
+++ b/Package/Sublime Text Snippet/Sublime Text Snippet.sublime-syntax
@@ -61,9 +61,8 @@ contexts:
           pop: true
         - include: scope:source.scope-selector
       with_prototype:
-        - match: '\s*(&amp;)\s*'
-          captures:
-            1: keyword.operator.with.scope-selector
+        - match: '&amp;'
+          scope: keyword.operator.with.scope-selector
     - match: '(<)(tabTrigger)(>)'
       scope: meta.tag.xml
       captures:

--- a/Package/Sublime Text Snippet/syntax_test_snippet.xml
+++ b/Package/Sublime Text Snippet/syntax_test_snippet.xml
@@ -301,7 +301,6 @@ ${TM_CURRENT_LINE/^\\s*((?:\\/\\/[\\/!]?|#|%|--|::|(?i:rem)|'|;)\\s*).*/$1/}
 #                          ^ invalid.illegal.newline-not-supported-here.sublime-snippet
 </scope>
 
-
 <scope>(source.c | source.c++) &amp; entity, (&amp;) | entity</scope>
 #      ^ punctuation.section.group.begin.scope-selector
 #       ^^^^^^ string.unquoted.scope-segment.scope-selector

--- a/Package/Sublime Text Snippet/syntax_test_snippet.xml
+++ b/Package/Sublime Text Snippet/syntax_test_snippet.xml
@@ -301,6 +301,26 @@ ${TM_CURRENT_LINE/^\\s*((?:\\/\\/[\\/!]?|#|%|--|::|(?i:rem)|'|;)\\s*).*/$1/}
 #                          ^ invalid.illegal.newline-not-supported-here.sublime-snippet
 </scope>
 
+
+<scope>(source.c | source.c++) &amp; entity, (&amp;) | entity</scope>
+#      ^ punctuation.section.group.begin.scope-selector
+#       ^^^^^^ string.unquoted.scope-segment.scope-selector
+#             ^ punctuation.separator.scope-segments.scope-selector
+#              ^ string.unquoted.scope-segment.scope-selector
+#                ^ keyword.operator.or.scope-selector
+#                  ^^^^^^ string.unquoted.scope-segment.scope-selector
+#                        ^ punctuation.separator.scope-segments.scope-selector
+#                         ^^^ string.unquoted.scope-segment.scope-selector
+#                            ^ punctuation.section.group.end.scope-selector
+#                              ^^^^^ keyword.operator.with.scope-selector
+#                                    ^^^^^^ string.unquoted.scope-segment.scope-selector
+#                                          ^ keyword.operator.or.scope-selector
+#                                            ^ punctuation.section.group.begin.scope-selector
+#                                             ^^^^^ keyword.operator.with.scope-selector
+#                                                  ^ punctuation.section.group.end.scope-selector
+#                                                    ^ keyword.operator.or.scope-selector
+#                                                      ^^^^^^ string.unquoted.scope-segment.scope-selector
+
 <tabTrigger> </tabTrigger>
 #^^^^^^^^^^ meta.tag.xml entity.name.tag.localname.xml meta.toc-list.trigger.sublime-snippet
 


### PR DESCRIPTION
Fixes #255

Remove capture groups to make `&amp;` being matched correctly within the Scope Selector.sublime-syntax