### PR TITLE
Settings: Improve completions of known values

### DIFF
--- a/plugins_/settings/known_settings.py
+++ b/plugins_/settings/known_settings.py
@@ -708,12 +708,18 @@ class KnownSettings(object):
         """
         hidden = get_setting('settings.exclude_color_scheme_patterns') or []
         completions = set()
+        for scheme_path in sublime.find_resources("*.sublime-color-scheme"):
+            if not any(hide in scheme_path for hide in hidden):
+                _, package, *_, name = scheme_path.split("/")
+                completions.add(format_completion_item(
+                    value=name, is_default=name == default, description=package))
+
         for scheme_path in sublime.find_resources("*.tmTheme"):
             if not any(hide in scheme_path for hide in hidden):
-                _, package, *_, file_name = scheme_path.split("/")
+                _, package, *_, name = scheme_path.split("/")
                 completions.add(format_completion_item(
                     value=scheme_path, is_default=scheme_path == default,
-                    label=file_name, description=package))
+                    label=name, description=package))
         return completions
 
     @staticmethod


### PR DESCRIPTION
Had a look at  8b904c6 and found some possible edge cases to fix.

While looking into it, I found the `(default)` marker not to be added to `color_scheme` and `theme` completions. Fixed it by extending the `format_completion_item()`. 

Finally found the `color_scheme` completions missing the `sublime-color-scheme` files and fixed it.

_Note:_

The extended `format_completion_item()` could be used in `_completions_from_comment()` and `_completions_from_default()` to add the `(default)` mark, which would result in `_marked_default_completions()` not being needed anymore. Left that for now as I am not sure whether it was the better alternative.

The main reason for extending `format_completion_item()` was to avoid breaking the description part of the completion label by calling `_marked_default_completions()`  on color_scheme, encoding or theme completions.