### PR TITLE
add scope completion for punctuation.definition.numeric.base

### DIFF
--- a/plugins_/lib/scope_data/data.py
+++ b/plugins_/lib/scope_data/data.py
@@ -195,6 +195,8 @@ DATA = """
             variable
                 begin
                 end
+            numeric
+                base
         section
             block
                 begin


### PR DESCRIPTION
This adds `punctuation.definition.numeric.base` to the scope data, so that it will be suggested in the auto completions when writing syntax definitions. (This was recently standardized, see i.e. https://github.com/sublimehq/Packages/pull/2175)