### PR TITLE
fix bug preventing whitespace in the syntax test token

### DIFF
--- a/plugins_/syntaxtest_dev.py
+++ b/plugins_/syntaxtest_dev.py
@@ -42,7 +42,7 @@ def get_syntax_test_tokens(view):
     match = None
     if line.size() < 1000:  # no point checking longer lines as they are unlikely to match
         first_line = view.substr(line)
-        match = re.match(r'^(?P<comment_start>\s*\S+)'
+        match = re.match(r'^(?P<comment_start>\s*.+)'
                          r'\s+SYNTAX TEST\s+'
                          r'"(?P<syntax_file>[^"]+)"'
                          r'\s*(?P<comment_end>\S+)?$', first_line)

--- a/plugins_/syntaxtest_dev.py
+++ b/plugins_/syntaxtest_dev.py
@@ -42,7 +42,7 @@ def get_syntax_test_tokens(view):
     match = None
     if line.size() < 1000:  # no point checking longer lines as they are unlikely to match
         first_line = view.substr(line)
-        match = re.match(r'^(?P<comment_start>\s*.+)'
+        match = re.match(r'^(?P<comment_start>\s*.+?)'
                          r'\s+SYNTAX TEST\s+'
                          r'"(?P<syntax_file>[^"]+)"'
                          r'\s*(?P<comment_end>\S+)?$', first_line)


### PR DESCRIPTION
ST supports whitespace in the middle of the syntax test token, but PackageDev wasn't offering any syntax test completions. This fixes that oversight to bring PackageDev back in line with ST behavior.