### PR TITLE
Revert "add scope completion for punctuation.definition.numeric.base"

### DIFF
--- a/plugins_/lib/scope_data/data.py
+++ b/plugins_/lib/scope_data/data.py
@@ -195,8 +195,6 @@ DATA = """
             variable
                 begin
                 end
-            numeric
-                base
         section
             block
                 begin


### PR DESCRIPTION
This reverts commit d59b57e6e2bd6f7b1c8214a355dccf8377b38940.

The sublimehq team has decided to remove this from the core syntaxes before a ST4 stable release.

The only reason for that not to have happened yet is the pending discussion at https://github.com/sublimehq/Packages/pull/2229, which should provide a the answer about how to go on either by adding the proposed meta.scopes or just remove the punctuation scope.

Therefore we should not encourage anyone to use those scopes in the meanwhile by adding them to the completions here.