### PR TITLE
Syntax: Fix highlighting of included contexts

### DIFF
--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
@@ -393,7 +393,7 @@ contexts:
                 - include: context_list_content
         # limit context to the current line
         - match: $|(?=\S)
-          pop: true
+          set: expect_include
     # maybe single include
     - match: (?=\S)
       set: expect_include

--- a/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
+++ b/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
@@ -289,6 +289,21 @@ contexts: !mytag
 
     - match: foo
       push:
+        !mytag scope
+#       ^^^^^^ storage.type.tag-handle.yaml
+#              ^^^^^ variable.other.sublime-syntax
+
+    - match: foo
+      push: scope
+#           ^^^^^ meta.include.sublime-syntax string.unquoted.plain.out.yaml variable.other.sublime-syntax
+
+    - match: foo
+      push:
+        scope
+#       ^^^^^ meta.include.sublime-syntax string.unquoted.plain.out.yaml variable.other.sublime-syntax
+
+    - match: foo
+      push:
         -
 #       ^ meta.expect-context-list-or-content punctuation.definition.block.sequence.item.yaml
 


### PR DESCRIPTION
It is a valid syntax to put the included context name to the line after a `push:` or `set:` statement.