### PR TITLE
Update XML hidden_extensions hotfix for latest ST3

### DIFF
--- a/plugins_/xml_hidden_extensions_hotfix.py
+++ b/plugins_/xml_hidden_extensions_hotfix.py
@@ -15,12 +15,12 @@ import sublime
 
 
 DEFAULT_VALUE = ["rss", "sublime-snippet", "vcproj", "tmLanguage", "tmTheme", "tmSnippet",
-                 "tmPreferences", "dae"]
-MODIFIED_VALUE = ["rss", "vcproj", "tmLanguage", "tmTheme", "tmSnippet", "dae"]
+                 "tmPreferences", "dae", "csproj"]
+MODIFIED_VALUE = ["rss", "vcproj", "tmLanguage", "tmTheme", "tmSnippet", "dae", "csproj"]
 
 # Encode ST build and date of last change (of this file) into the bootstrap value.
 # I'm not sure what exactly I'm gonna do with it, so just include info I might find useful later.
-BOOTSTRAP_VALUE = [3126, 2017, 3, 13]
+BOOTSTRAP_VALUE = [3210, 2020, 4, 7]
 
 
 def plugin_loaded():


### PR DESCRIPTION
For those of us who started using PackageDev from [this time](https://github.com/sublimehq/Packages/commit/4a3712b7e236f8c4b443282d97bad17f68df318c) onwards, the magic in this plugin will never have been run.