### PR TITLE
correctly handle indentation keywords in the syntax test header

### DIFF
--- a/plugins_/syntaxtest_dev.py
+++ b/plugins_/syntaxtest_dev.py
@@ -23,7 +23,7 @@ AssertionLineDetails = namedtuple(
     'AssertionLineDetails', ['comment_marker_match', 'assertion_colrange', 'line_region']
 )
 SyntaxTestHeader = namedtuple(
-    'SyntaxTestHeader', ['comment_start', 'comment_end', 'syntax_file']
+    'SyntaxTestHeader', ['comment_start', 'comment_end', 'syntax_file', 'reindent']
 )
 
 
@@ -44,6 +44,7 @@ def get_syntax_test_tokens(view):
         first_line = view.substr(line)
         match = re.match(r'^(?P<comment_start>\s*.+?)'
                          r'\s+SYNTAX TEST\s+'
+                         r'(?P<reindent>(?:reindent(?:-un(?:indented|changed))?\s+)*)'
                          r'"(?P<syntax_file>[^"]+)"'
                          r'\s*(?P<comment_end>\S+)?$', first_line)
     if not match:


### PR DESCRIPTION
support for this was added in Sublime Text build 4069. Without this change, syntax test files that also test indentation were not being detected by PackageDev's syntax test helper plugin. With this change, we don't do anything with the information that indentation is also being tested (except store it in the `SyntaxTestHeader`), but it allows the plugin to operate normally.