### PR TITLE
Syntax: Add highlighting for section comments

### DIFF
--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
@@ -87,6 +87,13 @@ variables:
 
 contexts:
   comment:
+    ###[ SECTION COMMENT ]######
+    - match: ^#+(\[)\s*([^#\]]+?)\s*(\])#+$
+      scope: comment.line.double-dash.syntax
+      captures:
+        1: punctuation.section.brackets.begin.syntax
+        2: entity.name.section.syntax
+        3: punctuation.section.brackets.end.syntax
     - include: Packages/YAML/YAML.sublime-syntax#comment
 
   main:

--- a/Package/Sublime Text Syntax Definition/Symbols - Section.tmPreferences
+++ b/Package/Sublime Text Syntax Definition/Symbols - Section.tmPreferences
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>scope</key>
+    <string>source.yaml.sublime.syntax entity.name.section</string>
+    <key>settings</key>
+    <dict>
+        <key>showInSymbolList</key>
+        <integer>1</integer>
+        <key>showInIndexedSymbolList</key>
+        <integer>0</integer>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
It's not an official feature of a sublime-syntax file, but as I started to split syntaxes into sections for better readability I'd find it a good idea to also use them for navigation.

Syntaxes which make use of sections are:

- HTML (ASP) (master)
- Bash (master)
- CSS (master)
- Erlang (master)
- Haskell (see: https://github.com/sublimehq/Packages/pull/2679)
- HTML (master)
- Java (see: https://github.com/sublimehq/Packages/pull/2654)
- Markdown (some in master)
- Matlab (see: https://github.com/sublimehq/Packages/pull/2650)
- Perl (master)
- Ruby (some in master)
- XML (master)

Inspired by the contexts recently added to R.
see: https://github.com/sublimehq/Packages/commit/d43b3b7f92d306cfad6cac8e0c0574ef5f4afff5