### PR TITLE
Syntax: Add scope for comparison operator

### DIFF
--- a/plugins/lib/scope_data/data.py
+++ b/plugins/lib/scope_data/data.py
@@ -112,6 +112,7 @@ DATA = """
             assignment
             arithmetic
             bitwise
+            comparison
             logical
             word
         other


### PR DESCRIPTION
Is used by a fair enough number of default syntaxes.