### PR TITLE
Syntax: Fix testcase scope completion

### DIFF
--- a/plugins/syntaxtest_dev.py
+++ b/plugins/syntaxtest_dev.py
@@ -347,7 +347,7 @@ class PackagedevSuggestSyntaxTestCommand(sublime_plugin.TextCommand):
 
         if character == '-':
             length = 1
-            scopes = {view.scope_name(line.begin() + col)}
+            scopes = {view.scope_name(line.begin() + lines[0].assertion_colrange[0])}
         elif character == '^':
             length, scopes = self.determine_test_extends(lines, line, col)
         else:


### PR DESCRIPTION
This commit fixes an issue which causes wrong selectors to be suggested, when typing following test cases:

    // <-|
    ## <-|

  Note: `|` denotes the caret.

The reason is the caret's column being used to extract scope names instead of the one from the calculated assertion range. The assertion's column is the one of the first character of the comment punctuation.

before this commit:

    </style>
    ## <- meta.tag.style.end.html entity.name.tag.style.html

with this commit:

    </style>
    ## <-  meta.tag.style.end.html punctuation.definition.tag.begin.html