### PR TITLE
Syntax: Update input helper

### DIFF
--- a/Package/Default.sublime-keymap
+++ b/Package/Default.sublime-keymap
@@ -100,14 +100,6 @@
             { "key": "setting.packagedev.syntax.input_helpers" },
         ]
     },
-    {   // [optional] move caret to the next line and indent by one level.
-        "keys": ["enter"], "command": "insert", "args": {"characters": "\n  "}, "context": [
-            { "key": "preceding_text", "operator": "regex_match", "operand": "^ {4,}-\\s*match:.*$", "match_all": true },
-            { "key": "selection_empty", "match_all": true },
-            { "key": "selector", "operand": "source.yaml.sublime.syntax" },
-            { "key": "setting.packagedev.syntax.input_helpers" },
-        ]
-    },
     /* end of syntax_dev keys */
 
     /* start of syntax_test_dev keys */

--- a/Package/Default.sublime-keymap
+++ b/Package/Default.sublime-keymap
@@ -84,11 +84,27 @@
             { "key": "setting.packagedev.syntax.input_helpers" },
         ]
     },
-    {   // [optional] auto-insert newline after double-colon (contexts) and 'captures'
+    {   // [optional] auto-insert newline after double-colon of 'captures'
         "keys": [":"], "command": "insert", "args": { "characters": ":\n" }, "context": [
-            { "key": "preceding_text", "operator": "regex_match", "operand": "^ {0,2}[^\\s:]+$|^ {4,}(- *)?(captures)+$", "match_all": true },
+            { "key": "preceding_text", "operator": "regex_match", "operand": "^ {4,}(- *)?(captures)+$", "match_all": true },
             { "key": "selection_empty", "match_all": true },
             { "key": "selector", "operand": "meta.block.contexts.sublime-syntax" },
+            { "key": "setting.packagedev.syntax.input_helpers" },
+        ]
+    },
+    {   // [optional] trim space after colon and insert newline.
+        "keys": ["enter"],  "command": "run_macro_file", "args": {"file": "res://Packages/PackageDev/Package/Sublime Text Syntax Definition/Trim Add Newline.sublime-macro"}, "context": [
+            { "key": "preceding_text", "operator": "regex_match", "operand": "^ {4,}(?:- )?[^\\s:]+:\\s+$", "match_all": true },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "selector", "operand": "source.yaml.sublime.syntax" },
+            { "key": "setting.packagedev.syntax.input_helpers" },
+        ]
+    },
+    {   // [optional] move caret to the next line and indent by one level.
+        "keys": ["enter"], "command": "insert", "args": {"characters": "\n  "}, "context": [
+            { "key": "preceding_text", "operator": "regex_match", "operand": "^ {4,}-\\s*match:.*$", "match_all": true },
+            { "key": "selection_empty", "match_all": true },
+            { "key": "selector", "operand": "source.yaml.sublime.syntax" },
             { "key": "setting.packagedev.syntax.input_helpers" },
         ]
     },

--- a/Package/Sublime Text Syntax Definition/Oniguruma RegExp Indentation Rules.tmPreferences
+++ b/Package/Sublime Text Syntax Definition/Oniguruma RegExp Indentation Rules.tmPreferences
@@ -24,6 +24,8 @@
         <false/>
         <key>increaseIndentPattern</key>
         <string><![CDATA[(?x)
+            # indent after match rule to continue writing with `scope`, `push`, ...
+            ^[ ]+-[ ]*match:.* |
             # define sub-expressions
             (?<not_paren>
                 [^\\()]++              # anything that isn't a slash or a paren

--- a/Package/Sublime Text Syntax Definition/Trim Add Newline.sublime-macro
+++ b/Package/Sublime Text Syntax Definition/Trim Add Newline.sublime-macro
@@ -1,0 +1,4 @@
+[
+    { "command": "delete_word", "args": {"forward": false} },
+    { "command": "insert", "args": {"characters": ":\n"} }
+]


### PR DESCRIPTION
This PR proposes to ...

1. align the caret with the `match` keyword when pressing enter.

   The result is:
   ```
   - match: pattern
     |
   ```

   Before it was:

   ```
   - match: pattern
   |
   ```

   Note: This might also be achieved by indentation rules, but I had no luck with them so far.

2. trim spaces after `push: `, `set: `, ... if enter is pressed and adds an indented line afterwards.

   Note: The macro works only for this special purpose as `delete_word` also removes the colon.

3. removes automatic insertion of linefeed when typing colon after context names as it often ends in empty lines after editing context names.