### PR TITLE
Syntax: Add kind info for ST4

### DIFF
--- a/plugins/lib/scope_data/__init__.py
+++ b/plugins/lib/scope_data/__init__.py
@@ -1,8 +1,11 @@
 import logging
+import sublime
 
 from .data import DATA
 
 __all__ = ["COMPILED_NODES", "COMPILED_HEADS", "completions_from_prefix"]
+
+HAVE_KINDS = hasattr(sublime, 'CompletionItem')
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +17,7 @@ class NodeSet(set):
         * find_all(name)
         * to_completion()
     """
+
     def find(self, name):
         for node in self:
             if node == name:
@@ -28,8 +32,10 @@ class NodeSet(set):
         return res
 
     def to_completion(self):
-        # return zip(self, self)
-        return list(sorted((n.name + "\tconvention", n.name) for n in self))
+        if HAVE_KINDS:
+            kind = (sublime.KIND_ID_NAMESPACE, "s", "Scope")
+            return [sublime.CompletionItem(n.name, annotation="convention", kind=kind) for n in self]
+        return sorted((n.name + "\tconvention", n.name) for n in self)
 
 
 class ScopeNode(object):

--- a/plugins/syntax_dev/__init__.py
+++ b/plugins/syntax_dev/__init__.py
@@ -1,0 +1,2 @@
+from .completions import *
+from .highlighter import *

--- a/plugins/syntax_dev/completions.py
+++ b/plugins/syntax_dev/completions.py
@@ -142,37 +142,37 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
     @_inhibit_word_completions
     def on_query_completions(self, prefix, locations):
 
-        def verify_scope(selector, offset=0):
+        def match_selector(selector, offset=0):
             """Verify scope for each location."""
             return all(self.view.match_selector(point + offset, selector)
                        for point in locations)
 
         # None of our business
-        if not verify_scope("- comment - (source.regexp - keyword.other.variable)"):
+        if not match_selector("- comment - (source.regexp - keyword.other.variable)"):
             return None
 
         # Scope name completions based on our scope_data database
-        if verify_scope("meta.expect-scope, meta.scope", -1):
+        if match_selector("meta.expect-scope, meta.scope", -1):
             return self._complete_scope(prefix, locations)
 
         # Auto-completion for include values using the 'contexts' keys and for
-        if verify_scope("meta.expect-context-list-or-content"
-                        " | meta.context-list-or-content", -1):
+        if match_selector("meta.expect-context-list-or-content"
+                          " | meta.context-list-or-content", -1):
             return self._complete_keyword(prefix, locations) + \
                 self._complete_context(prefix, locations)
 
         # Auto-completion for include values using the 'contexts' keys
-        if verify_scope("meta.expect-context-list | meta.expect-context"
-                        " | meta.include | meta.context-list", -1):
+        if match_selector("meta.expect-context-list | meta.expect-context"
+                          " | meta.include | meta.context-list", -1):
             return self._complete_context(prefix, locations)
 
         # Auto-completion for branch points with 'fail' key
-        if verify_scope("meta.expect-branch-point-reference"
-                        " | meta.branch-point-reference", -1):
+        if match_selector("meta.expect-branch-point-reference"
+                          " | meta.branch-point-reference", -1):
             return self._complete_branch_point()
 
         # Auto-completion for variables in match patterns using 'variables' keys
-        if verify_scope("keyword.other.variable"):
+        if match_selector("keyword.other.variable"):
             return self._complete_variable()
 
         # Standard completions for unmatched regions
@@ -208,7 +208,7 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
 
     def _complete_keyword(self, prefix, locations):
 
-        def verify_scope(selector, offset=0):
+        def match_selector(selector, offset=0):
             """Verify scope for each location."""
             return all(self.view.match_selector(point + offset, selector)
                        for point in locations)
@@ -231,7 +231,7 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
             return None
         elif not match.group(1):
             return self.base_completions_root
-        elif verify_scope("meta.block.contexts"):
+        elif match_selector("meta.block.contexts"):
             return self.base_completions_contexts
         else:
             return None

--- a/plugins/syntax_dev/completions.py
+++ b/plugins/syntax_dev/completions.py
@@ -76,26 +76,6 @@ def format_completions(items, annotation="", kind=sublime.KIND_AMBIGUOUS):
     ]
 
 
-def format_branch_completions(items):
-    return format_completions(items, "", KIND_BRANCH)
-
-
-def format_context_completions(items):
-    return format_completions(items, "", KIND_CONTEXT)
-
-
-def format_base_completion(item):
-    return format_completions([[item, None], ], "base suffix", KIND_SCOPE)
-
-
-def format_scope_completions(items):
-    return format_completions(items, "convention", KIND_SCOPE)
-
-
-def format_variable_completions(items):
-    return format_completions(items, "", KIND_VARIABLE)
-
-
 class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
 
     base_completions_root = format_static_completions(templates=(
@@ -214,12 +194,16 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
                 # print("Unexpected prefix mismatch: {} vs {}".format(real_prefix, prefix))
                 return []
 
-        return format_context_completions(
-            [
-                self.view.substr(r),
-                self.view.rowcol(r.begin())[0] + 1
-            ]
-            for r in self.view.find_by_selector("entity.name.function.context")
+        return format_completions(
+            (
+                [
+                    self.view.substr(r),
+                    self.view.rowcol(r.begin())[0] + 1
+                ]
+                for r in self.view.find_by_selector("entity.name.function.context")
+            ),
+            annotation="",
+            kind=KIND_CONTEXT
         )
 
     def _complete_keyword(self, prefix, locations):
@@ -307,25 +291,32 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
             return []
 
         self.base_suffix = base_suffix
-
-        return format_base_completion(base_suffix)
+        return format_completions([[base_suffix, None], ], "base suffix", KIND_SCOPE)
 
     def _complete_variable(self):
-        return format_variable_completions(
-            [
-                self.view.substr(r),
-                self.view.rowcol(r.begin())[0] + 1
-            ]
-            for r in self.view.find_by_selector("entity.name.constant")
+        return format_completions(
+            (
+                [
+                    self.view.substr(r),
+                    self.view.rowcol(r.begin())[0] + 1
+                ]
+                for r in self.view.find_by_selector("entity.name.constant")
+            ),
+            annotation="",
+            kind=KIND_VARIABLE
         )
 
     def _complete_branch_point(self):
-        return format_branch_completions(
-            [
-                self.view.substr(r),
-                self.view.rowcol(r.begin())[0] + 1
-            ]
-            for r in self.view.find_by_selector("entity.name.label.branch-point")
+        return format_completions(
+            (
+                [
+                    self.view.substr(r),
+                    self.view.rowcol(r.begin())[0] + 1
+                ]
+                for r in self.view.find_by_selector("entity.name.label.branch-point")
+            ),
+            annotation="",
+            kind=KIND_BRANCH
         )
 
 

--- a/plugins/syntax_dev/completions.py
+++ b/plugins/syntax_dev/completions.py
@@ -4,16 +4,25 @@ import re
 import sublime
 import sublime_plugin
 
-from sublime_lib.flags import RegionOption
-
-from .lib.scope_data import COMPILED_HEADS
-from .lib import syntax_paths
+from ..lib.scope_data import COMPILED_HEADS
+from ..lib import syntax_paths
 
 __all__ = (
-    'SyntaxDefRegexCaptureGroupHighlighter',
     'SyntaxDefCompletionsListener',
     'PackagedevCommitScopeCompletionCommand'
 )
+
+
+# a list of kinds used to denote the different kinds of completions
+KIND_HEADER_BASE = (sublime.KIND_ID_NAMESPACE, 'K', 'Header Key')
+KIND_HEADER_DICT = (sublime.KIND_ID_NAMESPACE, 'D', 'Header Dict')
+KIND_HEADER_LIST = (sublime.KIND_ID_NAMESPACE, 'L', 'Header List')
+KIND_BRANCH = (sublime.KIND_ID_NAVIGATION, 'b', 'Branch Point')
+KIND_CONTEXT = (sublime.KIND_ID_KEYWORD, 'c', 'Context')
+KIND_FUNCTION = (sublime.KIND_ID_FUNCTION, 'f', 'Function')
+KIND_CAPTURUE = (sublime.KIND_ID_FUNCTION, 'c', 'Captures')
+KIND_SCOPE = (sublime.KIND_ID_NAMESPACE, 's', 'Scope')
+KIND_VARIABLE = (sublime.KIND_ID_VARIABLE, 'v', 'Variable')
 
 PACKAGE_NAME = __package__.split('.')[0]
 
@@ -23,98 +32,6 @@ def status(msg, console=False):
     sublime.status_message(msg)
     if console:
         print(msg)
-
-
-class SyntaxDefRegexCaptureGroupHighlighter(sublime_plugin.ViewEventListener):
-
-    # TODO multiple views into the same file
-
-    @classmethod
-    def is_applicable(cls, settings):
-        return settings.get('syntax') == syntax_paths.SYNTAX_DEF
-
-    def on_selection_modified(self):
-        prefs = sublime.load_settings('PackageDev.sublime-settings')
-        scope = prefs.get('syntax.captures_highlight_scope', "text")
-        styles = prefs.get('syntax.captures_highlight_styles', ['DRAW_NO_FILL'])
-
-        style_flags = RegionOption(*styles)
-
-        self.view.add_regions(
-            key='captures',
-            regions=list(self.get_regex_regions()),
-            scope=scope,
-            flags=style_flags,
-        )
-
-    def get_regex_regions(self):
-        locations = [
-            region.begin()
-            for selection in self.view.sel()
-            if self.view.match_selector(
-                selection.begin(),
-                'source.yaml.sublime.syntax meta.expect-captures'
-            )
-            for region in self.view.split_by_newlines(selection)
-        ]
-
-        for loc in locations:
-            # Find the line number.
-            match = re.search(r'(\d+):', self.view.substr(self.view.line(loc)))
-            if not match:
-                continue
-            n = int(match.group(1))
-
-            # Find the associated regexp. Assume it's the preceding one.
-            try:
-                regexp_region = [
-                    region
-                    for region in self.view.find_by_selector('source.regexp.oniguruma')
-                    if region.end() < loc
-                ][-1]
-            except IndexError:
-                continue
-
-            if n == 0:
-                yield regexp_region
-                continue
-
-            # Find parens that define capture groups.
-            regexp_offset = regexp_region.begin()
-            parens = iter(
-                (match.group(), match.start() + regexp_offset)
-                for match in re.finditer(r'\(\??|\)', self.view.substr(regexp_region))
-                if self.view.match_selector(
-                    match.start() + regexp_offset,
-                    'keyword.control.group'
-                )
-            )
-
-            # Find the start of the nth capture group.
-            start = None
-            count = 0
-            for p, i in parens:
-                if p == '(':  # Not (?
-                    count += 1
-                    if count == n:
-                        start = i
-                        break
-
-            # Find the end of that capture group
-            end   = None
-            depth = 0
-            for p, i in parens:
-                if p in {'(', '(?'}:
-                    depth += 1
-                else:
-                    if depth == 0:
-                        end = i + 1
-                        break
-                    else:
-                        depth -= 1
-
-            if end is not None:
-                yield sublime.Region(start, end)
 
 
 def _inhibit_word_completions(func):
@@ -127,107 +44,56 @@ def _inhibit_word_completions(func):
     return wrapper
 
 
-HAVE_KINDS = hasattr(sublime, 'CompletionItem')
-if HAVE_KINDS:
+def format_static_completions(templates):
 
-    # a list of kinds used to denote the different kinds of completions
-    KIND_HEADER_BASE = (sublime.KIND_ID_NAMESPACE, 'K', 'Header Key')
-    KIND_HEADER_DICT = (sublime.KIND_ID_NAMESPACE, 'D', 'Header Dict')
-    KIND_HEADER_LIST = (sublime.KIND_ID_NAMESPACE, 'L', 'Header List')
-    KIND_BRANCH = (sublime.KIND_ID_NAVIGATION, 'b', 'Branch Point')
-    KIND_CONTEXT = (sublime.KIND_ID_KEYWORD, 'c', 'Context')
-    KIND_FUNCTION = (sublime.KIND_ID_FUNCTION, 'f', 'Function')
-    KIND_CAPTURUE = (sublime.KIND_ID_FUNCTION, 'c', 'Captures')
-    KIND_SCOPE = (sublime.KIND_ID_NAMESPACE, 's', 'Scope')
-    KIND_VARIABLE = (sublime.KIND_ID_VARIABLE, 'v', 'Variable')
+    def format_item(trigger, kind, details):
+        if kind in (KIND_HEADER_DICT, KIND_CAPTURUE, KIND_CONTEXT):
+            completion_format = sublime.COMPLETION_FORMAT_SNIPPET
+            suffix = ":\n  "
+        elif kind is KIND_HEADER_LIST:
+            completion_format = sublime.COMPLETION_FORMAT_SNIPPET
+            suffix = ":\n  - "
+        else:
+            completion_format = sublime.COMPLETION_FORMAT_TEXT
+            suffix = ": "
 
-    def format_static_completions(templates):
+        return sublime.CompletionItem(
+            trigger=trigger, kind=kind, details=details,
+            completion=trigger + suffix, completion_format=completion_format
+        )
 
-        def format_item(trigger, kind, details):
-            if kind in (KIND_HEADER_DICT, KIND_CAPTURUE, KIND_CONTEXT):
-                completion_format = sublime.COMPLETION_FORMAT_SNIPPET
-                suffix = ":\n  "
-            elif kind is KIND_HEADER_LIST:
-                completion_format = sublime.COMPLETION_FORMAT_SNIPPET
-                suffix = ":\n  - "
-            else:
-                completion_format = sublime.COMPLETION_FORMAT_TEXT
-                suffix = ": "
+    return [format_item(*template) for template in templates]
 
-            return sublime.CompletionItem(
-                trigger=trigger, kind=kind, details=details,
-                completion=trigger + suffix, completion_format=completion_format
-            )
 
-        return [format_item(*template) for template in templates]
+def format_completions(items, annotation="", kind=sublime.KIND_AMBIGUOUS):
+    format_string = "Defined at line <a href='subl:goto_line {{\"line\": \"{0}\"}}'>{0}</a>"
+    return [
+        sublime.CompletionItem(
+            trigger=trigger, annotation=annotation, kind=kind,
+            details=format_string.format(row) if row is not None else ""
+        )
+        for trigger, row in items
+    ]
 
-    def format_completions(items, annotation="", kind=sublime.KIND_AMBIGUOUS):
-        format_string = "Defined at line <a href='subl:goto_line {{\"line\": \"{0}\"}}'>{0}</a>"
-        return [
-            sublime.CompletionItem(
-                trigger=trigger, annotation=annotation, kind=kind,
-                details=format_string.format(row) if row is not None else ""
-            )
-            for trigger, row in items
-        ]
 
-    def format_branch_completions(items):
-        return format_completions(items, "", KIND_BRANCH)
+def format_branch_completions(items):
+    return format_completions(items, "", KIND_BRANCH)
 
-    def format_context_completions(items):
-        return format_completions(items, "", KIND_CONTEXT)
 
-    def format_base_completion(item):
-        return format_completions([[item, None], ], "base suffix", KIND_SCOPE)
+def format_context_completions(items):
+    return format_completions(items, "", KIND_CONTEXT)
 
-    def format_scope_completions(items):
-        return format_completions(items, "convention", KIND_SCOPE)
 
-    def format_variable_completions(items):
-        return format_completions(items, "", KIND_VARIABLE)
+def format_base_completion(item):
+    return format_completions([[item, None], ], "base suffix", KIND_SCOPE)
 
-else:
 
-    KIND_HEADER_BASE = ''
-    KIND_HEADER_DICT = ''
-    KIND_HEADER_LIST = ''
-    KIND_BRANCH = ''
-    KIND_CONTEXT = ''
-    KIND_FUNCTION = ''
-    KIND_CAPTURUE = ''
-    KIND_VARIABLE = ''
+def format_scope_completions(items):
+    return format_completions(items, "convention", KIND_SCOPE)
 
-    def format_static_completions(templates):
 
-        def format_item(trigger, kind, details):
-            if kind in (KIND_HEADER_DICT, KIND_CAPTURUE, KIND_CONTEXT):
-                suffix = ":\n  "
-            elif kind is KIND_HEADER_LIST:
-                suffix = ":\n  - "
-            else:
-                suffix = ": "
-
-            return ("{0}\t{1}".format(trigger, details), trigger + suffix)
-
-        return [format_item(*template) for template in templates]
-
-    def format_completions(items, kind):
-        return [trigger + kind for trigger, _ in items]
-
-    def format_base_completion(item):
-        return [item + "\tbase suffix"]
-
-    def format_branch_completions(items):
-        return format_completions(items, "\tbranch point")
-
-    def format_context_completions(items):
-        return format_completions(items, "\tcontext")
-
-    def format_scope_completions(items):
-        return format_completions(items, "\tconvention")
-
-    def format_variable_completions(items):
-        return format_completions(items, "\tvariable")
+def format_variable_completions(items):
+    return format_completions(items, "", KIND_VARIABLE)
 
 
 class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):

--- a/plugins/syntax_dev/completions.py
+++ b/plugins/syntax_dev/completions.py
@@ -189,10 +189,10 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
             line_prefix = self._line_prefix(point)
             real_prefix = re.search(r"[^,\[ ]*$", line_prefix).group(0)
             if real_prefix.startswith("scope:") or "/" in real_prefix:
-                return []  # Don't show any completions here
+                return None  # Don't show any completions here
             elif real_prefix != prefix:
                 # print("Unexpected prefix mismatch: {} vs {}".format(real_prefix, prefix))
-                return []
+                return None
 
         return format_completions(
             (
@@ -280,7 +280,7 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
         if len(regions) != 1:
             status("Warning: Could not determine base scope uniquely", console=True)
             self.base_suffix = None
-            return []
+            return None
 
         base_scope = self.view.substr(regions[0])
         *_, base_suffix = base_scope.rpartition(".")
@@ -288,7 +288,7 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
         # In this case it is even useful to inhibit other completions completely
         if last_token == base_suffix:
             self.base_suffix = None
-            return []
+            return None
 
         self.base_suffix = base_suffix
         return format_completions([[base_suffix, None], ], "base suffix", KIND_SCOPE)

--- a/plugins/syntax_dev/highlighter.py
+++ b/plugins/syntax_dev/highlighter.py
@@ -1,0 +1,106 @@
+import re
+
+import sublime
+import sublime_plugin
+
+from sublime_lib.flags import RegionOption
+
+from ..lib import syntax_paths
+
+__all__ = (
+    'SyntaxDefRegexCaptureGroupHighlighter',
+)
+
+
+class SyntaxDefRegexCaptureGroupHighlighter(sublime_plugin.ViewEventListener):
+
+    @classmethod
+    def applies_to_primary_view_only(cls):
+        return False
+
+    @classmethod
+    def is_applicable(cls, settings):
+        return settings.get('syntax') == syntax_paths.SYNTAX_DEF
+
+    def on_selection_modified(self):
+        prefs = sublime.load_settings('PackageDev.sublime-settings')
+        scope = prefs.get('syntax.captures_highlight_scope', "text")
+        styles = prefs.get('syntax.captures_highlight_styles', ['DRAW_NO_FILL'])
+
+        style_flags = RegionOption(*styles)
+
+        self.view.add_regions(
+            key='captures',
+            regions=list(self.get_regex_regions()),
+            scope=scope,
+            flags=style_flags,
+        )
+
+    def get_regex_regions(self):
+        locations = [
+            region.begin()
+            for selection in self.view.sel()
+            if self.view.match_selector(
+                selection.begin(),
+                'source.yaml.sublime.syntax meta.expect-captures'
+            )
+            for region in self.view.split_by_newlines(selection)
+        ]
+
+        for loc in locations:
+            # Find the line number.
+            match = re.search(r'(\d+):', self.view.substr(self.view.line(loc)))
+            if not match:
+                continue
+            n = int(match.group(1))
+
+            # Find the associated regexp. Assume it's the preceding one.
+            try:
+                regexp_region = [
+                    region
+                    for region in self.view.find_by_selector('source.regexp.oniguruma')
+                    if region.end() < loc
+                ][-1]
+            except IndexError:
+                continue
+
+            if n == 0:
+                yield regexp_region
+                continue
+
+            # Find parens that define capture groups.
+            regexp_offset = regexp_region.begin()
+            parens = iter(
+                (match.group(), match.start() + regexp_offset)
+                for match in re.finditer(r'\(\??|\)', self.view.substr(regexp_region))
+                if self.view.match_selector(
+                    match.start() + regexp_offset,
+                    'keyword.control.group'
+                )
+            )
+
+            # Find the start of the nth capture group.
+            start = None
+            count = 0
+            for p, i in parens:
+                if p == '(':  # Not (?
+                    count += 1
+                    if count == n:
+                        start = i
+                        break
+
+            # Find the end of that capture group
+            end = None
+            depth = 0
+            for p, i in parens:
+                if p in {'(', '(?'}:
+                    depth += 1
+                else:
+                    if depth == 0:
+                        end = i + 1
+                        break
+                    else:
+                        depth -= 1
+
+            if end is not None:
+                yield sublime.Region(start, end)


### PR DESCRIPTION
This PR...

1. is meant for ST4 only at its final stage. (Until https://github.com/SublimeText/PackageDev/commit/122beaa680bc5dbfd831563a4c4166dffa651699 both ST3 and 4 are supported).
2. creates a `syntax_dev` package to split highlighting and completions into separate modules.
3. completions from base syntaxes are still missing (`extends` needs to be added).

It is a set of ideas of how completions may work in future releases. It already works pretty good - may need some structural improvements though.