### PR TITLE
TextMate: use the correct brand capitalization

### DIFF
--- a/Package/Main.sublime-menu
+++ b/Package/Main.sublime-menu
@@ -90,7 +90,7 @@
                 "command": "packagedev_new_resource",
                 "args": {"kind": "settings"}
               },
-              { "caption": "New Textmate Preferences File…",
+              { "caption": "New TextMate Preferences File…",
                 "command": "packagedev_new_resource",
                 "args": {"kind": "tm_preferences"}
               },

--- a/Package/PackageDev.sublime-commands
+++ b/Package/PackageDev.sublime-commands
@@ -107,7 +107,7 @@
     "command": "packagedev_new_resource",
     "args": {"kind": "settings"}
   },
-  { "caption": "PackageDev: New Textmate Preferences File",
+  { "caption": "PackageDev: New TextMate Preferences File",
     "command": "packagedev_new_resource",
     "args": {"kind": "tm_preferences"}
   },


### PR DESCRIPTION
Seems like every other occurrence is either a capitalized proper name,
or a fully lowercase identifier (e.g. in a scope name).

---

This is a legit one-letter-fix PR. I'm so sorry everyone.

PS Don't forget to tag [@shitoberfest](https://twitter.com/shitoberfest/) when posting this.