### PR TITLE
Color Scheme: Remove CSS.sublime-syntax#percentage-value

### DIFF
--- a/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-syntax
+++ b/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-syntax
@@ -393,7 +393,7 @@ contexts:
               pop: true
             - include: color-var-function
             - include: CSS.sublime-syntax#color-values
-            - include: CSS.sublime-syntax#numeric-values
+            - include: CSS.sublime-syntax#numeric-constants
         - match: (?=")
           pop: true
 

--- a/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-syntax
+++ b/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-syntax
@@ -393,7 +393,6 @@ contexts:
               pop: true
             - include: color-var-function
             - include: CSS.sublime-syntax#color-values
-            - include: CSS.sublime-syntax#percentage-type
             - include: CSS.sublime-syntax#numeric-values
         - match: (?=")
           pop: true


### PR DESCRIPTION
It is already included in `CSS.sublime-syntax#numeric-values`.