### PR TITLE
[ST4] Add new context keys.

### DIFF
--- a/Package/Sublime Text Keymap/Completions/Context Key Values.sublime-completions
+++ b/Package/Sublime Text Keymap/Completions/Context Key Values.sublime-completions
@@ -92,5 +92,35 @@
 			"details": "Match the scope at the end of the line",
 			"kind": ["variable", "k", "key"],
 		},
+		{
+			"trigger": "overlay_has_focus",
+			"details": "Overlay has focus",
+			"kind": ["variable", "k", "key"],
+		},
+		{
+			"trigger": "overlay_name",
+			"details": "Name of the overlay open",
+			"kind": ["variable", "k", "key"],
+		},
+		{
+			"trigger": "group_has_multiselect",
+			"details": "Group has multiselected tabs",
+			"kind": ["variable", "k", "key"],
+		},
+		{
+			"trigger": "group_has_transient_sheet",
+			"details": "Group has a transient sheet",
+			"kind": ["variable", "k", "key"],
+		},
+		{
+			"trigger": "has_snippet",
+			"details": "Word before cursor expands to a snippet",
+			"kind": ["variable", "k", "key"],
+		},
+		{
+			"trigger": "is_javadoc",
+			// "details": "TODO",
+			"kind": ["variable", "k", "key"],
+		}
 	]
 }

--- a/Package/Sublime Text Keymap/Sublime Text Keymap.sublime-syntax
+++ b/Package/Sublime Text Keymap/Sublime Text Keymap.sublime-syntax
@@ -425,8 +425,10 @@ contexts:
     - match: |-
         (?x)(")((?:preceding_|following_)?text|num_selections|selection_empty
                 |has_(?:next|prev)_field
-                |(?:panel|overlay|auto_complete|popup)_visible|panel|panel_has_focus
-                |last_command|indented_block
+                |(?:panel|auto_complete|popup)_visible|panel|panel_has_focus
+                |last_command|indented_block|has_snippet|is_javadoc
+                |overlay_(?:has_focus|visible|name)
+                |group_has_(?:multiselect|transient_sheet)
                )(")
       scope: meta.context.key-value.key.other.sublime-keymap string.quoted.double.json
       captures:


### PR DESCRIPTION
This PR adds context keys that have been added in various builds of ST4 starting from 4050. The following table summarizes them
| Key                           | Operand | Operators | Match All | Description                                                                | Added in |
|-------------------------------|---------|-----------|-----------|----------------------------------------------------------------------------|----------|
| `"overlay_has_focus"`         | boolean | equality  | no        | Whether the overlay currently open, has focus.                             | 4082     |
| `"overlay_name"`              | string  | equality  | no        | The name of the overlay. Valid values are `"goto"` & `"command_palette"`   | 4082     |
| `"group_has_multiselect"`     | boolean | equality  | no        | Whether the currently focused group has multi selected tabs.               | 4050     |
| `"group_has_transient_sheet"` | boolean | equality  | no        | Whether the currently focused group has a transient sheet.                 | 4050     |
| `"has_snippet"`               | boolean | equality  | no        | Whether the immediate word before the cursor can be expanded to a snippet.  | 4050     |
| `"is_javadoc"`                | boolean | equality  | yes       | <No Idea>                                                                  | 4050     |

As to the `is_javadoc` one, I have no idea how to trigger it & what it does. So I have marked the `details` for it as a TODO. 