### PR TITLE
[ST4] Add support for various `block_caret_` global settings in color schemes.

### DIFF
--- a/Package/Sublime Text Color Scheme/Completions/Globals Keys.sublime-completions
+++ b/Package/Sublime Text Color Scheme/Completions/Globals Keys.sublime-completions
@@ -44,6 +44,12 @@
             "kind": ["keyword", "k", "globals"],
         },
         {
+            "trigger": "block_caret_corner_radius",
+            "details": "Block caret corner radius",
+            "contents": "\"block_caret_corner_radius\": \"$1\",",
+            "kind": ["keyword", "k", "globals"],
+        },
+        {
             "trigger": "bracket_contents_foreground",
             "details": "Foreground color of highlighted brackets (inside)",
             "contents": "\"bracket_contents_foreground\": \"$1\",",

--- a/Package/Sublime Text Color Scheme/Completions/Globals Keys.sublime-completions
+++ b/Package/Sublime Text Color Scheme/Completions/Globals Keys.sublime-completions
@@ -26,6 +26,24 @@
             "kind": ["keyword", "k", "globals"],
         },
         {
+            "trigger": "block_caret_corner_style",
+            "details": "Block caret corner style",
+            "contents": "\"block_caret_corner_style\": \"$1\",",
+            "kind": ["keyword", "k", "globals"],
+        },
+        {
+            "trigger": "block_caret_border",
+            "details": "Block caret border color",
+            "contents": "\"block_caret_border\": \"$1\",",
+            "kind": ["keyword", "k", "globals"],
+        },
+        {
+            "trigger": "block_caret_underline",
+            "details": "Color of the block caret in selection",
+            "contents": "\"block_caret_underline\": \"$1\",",
+            "kind": ["keyword", "k", "globals"],
+        },
+        {
             "trigger": "bracket_contents_foreground",
             "details": "Foreground color of highlighted brackets (inside)",
             "contents": "\"bracket_contents_foreground\": \"$1\",",

--- a/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-syntax
+++ b/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-syntax
@@ -233,7 +233,7 @@ contexts:
           |brackets_foreground|bracket_contents_foreground|tags_foreground
           |minimap_border|gutter|gutter_foreground|rulers|fold_marker
           |line_diff_(?:modified|added|deleted) # added in 3186 & 3189
-          |block_caret(?:_(?:corner_style|border|underline)) # block_caret added in 3190, others in 4086.
+          |block_caret(?:_(?:corner_style|border|underline|corner_radius))? # block_caret added in 3190, others in 4086.
         )(")
       captures:
         1: punctuation.definition.string.begin.json

--- a/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-syntax
+++ b/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-syntax
@@ -233,7 +233,7 @@ contexts:
           |brackets_foreground|bracket_contents_foreground|tags_foreground
           |minimap_border|gutter|gutter_foreground|rulers|fold_marker
           |line_diff_(?:modified|added|deleted) # added in 3186 & 3189
-          |block_caret(?:_(?:corner_style|border|underline|corner_radius))? # block_caret added in 3190, others in 4086.
+          |block_caret(?:_(?:border|underline))? # block_caret added in 3190, others in 4086.
         )(")
       captures:
         1: punctuation.definition.string.begin.json
@@ -246,7 +246,7 @@ contexts:
         2: entity.name.globals.sublime-color-scheme
         3: punctuation.definition.string.end.json
       set: [expect-css-string-value, expect-colon]
-    - match: (")(shadow_width|selection_corner_radius|selection_border_width|line_diff_width)(")
+    - match: (")(shadow_width|(?:selection|block_caret)_corner_radius|selection_border_width|line_diff_width)(")
       captures:
         1: punctuation.definition.string.begin.json
         2: entity.name.globals.sublime-color-scheme
@@ -264,7 +264,7 @@ contexts:
         2: entity.name.globals.sublime-color-scheme
         3: punctuation.definition.string.end.json
       set: [expect-underlinestyle-string-value, expect-colon]
-    - match: (")(selection_corner_style)(")
+    - match: (")((?:selection|block_caret)_corner_style)(")
       captures:
         1: punctuation.definition.string.begin.json
         2: entity.name.globals.sublime-color-scheme

--- a/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-syntax
+++ b/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-syntax
@@ -233,7 +233,7 @@ contexts:
           |brackets_foreground|bracket_contents_foreground|tags_foreground
           |minimap_border|gutter|gutter_foreground|rulers|fold_marker
           |line_diff_(?:modified|added|deleted) # added in 3186 & 3189
-          |block_caret # added in 3190
+          |block_caret(?:_(?:corner_style|border|underline)) # block_caret added in 3190, others in 4086.
         )(")
       captures:
         1: punctuation.definition.string.begin.json


### PR DESCRIPTION
This PR
1. Adds appropriate completions for various `block_caret_` global settings introduced in 4086.
2. Adds these in the syntax file for appropriate highlighting.

Here is a brief summary of them.

1. `block_caret_corner_style`: Controls the corner style of block carets. Valid values are `cut`, `round` & `square`.
2. `block_caret_border`:  Controls the color of the block caret's border.
3. `block_caret_underline`: Controls the color of the block caret **inside a selection**. The color of the block caret inside a selection will fallback to the color of the `caret` global if `block_caret_underline` is not defined.
4. `block_caret_corner_radius`: Controls the corner radius of block caret. This value lies in the range `[0, 10]`