### PR TITLE
Scopes: Fix completions

### DIFF
--- a/plugins/lib/scope_data/__init__.py
+++ b/plugins/lib/scope_data/__init__.py
@@ -34,8 +34,7 @@ class NodeSet(set):
         return res
 
     def to_completion(self):
-        return [sublime.CompletionItem(n.name, annotation="convention", kind=SCOPE_KIND)
-                for n in sorted(self)]
+        return [sublime.CompletionItem(n.name, annotation="convention", kind=SCOPE_KIND) for n in self]
 
 
 class ScopeNode(object):


### PR DESCRIPTION
Not only `sorted` is useless because of ST sorting completion suggestions by relevance it also breaks the function itself.

The scope names don't have kind info or annotation applied.

Removing `sorted` fixes that.