### PR TITLE
[ST4] Some changes to build system completions & updating it's syntax.

### DIFF
--- a/Package/Sublime Text Build System/Completions/Exec Keys (in-string).sublime-completions
+++ b/Package/Sublime Text Build System/Completions/Exec Keys (in-string).sublime-completions
@@ -52,6 +52,11 @@
             "kind": ["keyword", "k", "exec"],
         },
         {
+            "trigger": "update_annotations_only",
+            "details": "Update annotations only",
+            "kind": ["keyword", "k", "exec"],
+        },
+        {
             "trigger": "word_wrap",
             "details": "Enable word wrapping for output panel",
             "kind": ["keyword", "k", "exec"],

--- a/Package/Sublime Text Build System/Completions/Exec Keys (in-string).sublime-completions
+++ b/Package/Sublime Text Build System/Completions/Exec Keys (in-string).sublime-completions
@@ -52,11 +52,6 @@
             "kind": ["keyword", "k", "exec"],
         },
         {
-            "trigger": "update_phantoms_only",
-            "details": "Just update phantoms",
-            "kind": ["keyword", "k", "exec"],
-        },
-        {
             "trigger": "word_wrap",
             "details": "Enable word wrapping for output panel",
             "kind": ["keyword", "k", "exec"],

--- a/Package/Sublime Text Build System/Completions/Exec Keys (in-string).sublime-completions
+++ b/Package/Sublime Text Build System/Completions/Exec Keys (in-string).sublime-completions
@@ -47,6 +47,11 @@
             "kind": ["keyword", "k", "exec"],
         },
         {
+            "trigger": "kill_previous",
+            "details": "Kill the previously runnning build",
+            "kind": ["keyword", "k", "exec"],
+        },
+        {
             "trigger": "update_phantoms_only",
             "details": "Just update phantoms",
             "kind": ["keyword", "k", "exec"],

--- a/Package/Sublime Text Build System/Completions/Exec Keys.sublime-completions
+++ b/Package/Sublime Text Build System/Completions/Exec Keys.sublime-completions
@@ -62,6 +62,12 @@
             "kind": ["keyword", "k", "exec"],
         },
         {
+            "trigger": "update_annotations_only",
+            "contents": "\"update_annotations_only\": true,$0",
+            "details": "Update annotations only",
+            "kind": ["keyword", "k", "exec"],
+        },
+        {
             "trigger": "word_wrap",
             "contents": "\"word_wrap\": \"$1\",$0",
             "details": "Enable word wrapping for output panel",

--- a/Package/Sublime Text Build System/Completions/Exec Keys.sublime-completions
+++ b/Package/Sublime Text Build System/Completions/Exec Keys.sublime-completions
@@ -62,12 +62,6 @@
             "kind": ["keyword", "k", "exec"],
         },
         {
-            "trigger": "update_phantoms_only",
-            "contents": "\"update_phantoms_only\": true,$0",
-            "details": "Just update phantoms",
-            "kind": ["keyword", "k", "exec"],
-        },
-        {
             "trigger": "word_wrap",
             "contents": "\"word_wrap\": \"$1\",$0",
             "details": "Enable word wrapping for output panel",

--- a/Package/Sublime Text Build System/Completions/Exec Keys.sublime-completions
+++ b/Package/Sublime Text Build System/Completions/Exec Keys.sublime-completions
@@ -56,6 +56,12 @@
             "kind": ["keyword", "k", "exec"],
         },
         {
+            "trigger": "kill_previous",
+            "contents": "\"kill_previous\": true,$0",
+            "details": "Kill the previously runnning build",
+            "kind": ["keyword", "k", "exec"],
+        },
+        {
             "trigger": "update_phantoms_only",
             "contents": "\"update_phantoms_only\": true,$0",
             "details": "Just update phantoms",

--- a/Package/Sublime Text Build System/Sublime Text Build System.sublime-syntax
+++ b/Package/Sublime Text Build System/Sublime Text Build System.sublime-syntax
@@ -133,7 +133,7 @@ contexts:
         2: support.function.exec-arg.sublime-build
         3: punctuation.definition.string.end.json
       set: [expect-regex-string-value, expect-colon]
-    - match: (")(shell|quiet|kill|update_phantoms_only|hide_phantoms_only|word_wrap)(")
+    - match: (")(shell|quiet|kill(?:_previous)?|update_annotations_only|word_wrap)(")
       scope: meta.mapping.key.json meta.main-key.sublime-build string.quoted.double.json
       captures:
         1: punctuation.definition.string.begin.json


### PR DESCRIPTION
This PR

1. Adds completions for `kill_previous` (introduced in 4092 to kill previously running builds) & `update_annotations_only` (introduced in 4050) to the build system completions file. These are also added to the syntax file for appropriate highlighting.
2. It removes any phantom related `exec` args from the completions & syntax file since phantoms are no longer used to show build errors in the buffer from 4050 onwards.