### PR TITLE
Themes: Add var() function support to color-adjuster context

### DIFF
--- a/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-syntax
+++ b/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-syntax
@@ -389,10 +389,10 @@ contexts:
       push:
         - meta_scope: meta.function-call.min-contrast.css
         - match: \)
-          scope: meta.group.css punctuation.definition.group.end.css
+          scope: meta.group.css punctuation.section.group.end.css
           pop: true
         - match: \(
-          scope: punctuation.definition.group.begin.css
+          scope: punctuation.section.group.begin.css
           push:
             - meta_scope: meta.group.css
             - match: (?=\))
@@ -433,11 +433,11 @@ contexts:
       push:
         - meta_scope: meta.function-call.var.css
         - match: \(
-          scope: punctuation.definition.group.begin.css
+          scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.var.css meta.group.css
             - match: \)
-              scope: meta.group.css punctuation.definition.group.end.css
+              scope: meta.group.css punctuation.section.group.end.css
               pop: true
             - match: (?:--)?[\w-]+
               scope: variable.other.sublime-color-scheme
@@ -478,6 +478,7 @@ contexts:
         - match: $\n?
           scope: invalid.illegal.unclosed-string.json
           pop: true
+        - include: color-var-function
         - include: CSS.sublime-syntax#color-adjuster-functions
 
   expect-css-string-value:

--- a/Package/Sublime Text Color Scheme/syntax_test_colorscheme.json
+++ b/Package/Sublime Text Color Scheme/syntax_test_colorscheme.json
@@ -51,9 +51,9 @@
 //                ^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value.json string.quoted.double.json meta.color.sublime-color-scheme
 //                ^ punctuation.definition.string.begin.json
 //                 ^^^ support.function.var.css
-//                    ^ punctuation.definition.group.begin.css
+//                    ^ punctuation.section.group.begin.css
 //                     ^^^^^^^^^^^^^^^^ variable.other.sublime-color-scheme
-//                                     ^ punctuation.definition.group.end.css
+//                                     ^ punctuation.section.group.end.css
 //                                      ^ punctuation.definition.string.end.json
 //                                       ^ punctuation.separator.mapping.pair.json
         "stack_guide": "#9D550FB0",

--- a/Package/Sublime Text Theme/syntax_test_newstyletheme.json
+++ b/Package/Sublime Text Theme/syntax_test_newstyletheme.json
@@ -136,6 +136,13 @@
 //                                  ^^^^^ support.function.color.css
 //                                       ^ punctuation.section.group.begin.css
 //                                        ^^^^^ support.constant
+            "background_modifier": "var(adjuster_variable)"
+//           ^^^^^^^^^^^^^^^^^^^ meta.rule-key.color-adjuster.sublime-theme string.quoted.double.json keyword.other.rule.sublime-theme
+//                                  ^^^^^^^^^^^^^^^^^^^^^^ meta.rule.sublime-theme meta.mapping.value.json string.quoted.double.json meta.color-adjuster.sublime-color-scheme source.css-color-adjuster
+//                                  ^^^ support.function.var.css
+//                                     ^ punctuation.section.group.begin.css
+//                                      ^^^^^^^^^^^^^^^^^ variable.other.sublime-color-scheme
+//                                                       ^ punctuation.section.group.end.css
         },
         { // floats
             "line_selection_border_width": "abc" 2.0,


### PR DESCRIPTION
This commit adds `color-var-function` context to `color-adjuster-string-pop` in order to highlight var() function correctly.

While adding test cases another inconsistency with regards to group punctuation was revealed and fixed.