### PR TITLE
[ST4] Make editing scheme/theme, OS aware when the corresponding is set to auto.

### DIFF
--- a/plugins/color_scheme_dev.py
+++ b/plugins/color_scheme_dev.py
@@ -278,10 +278,10 @@ class PackagedevEditSchemeCommand(sublime_plugin.WindowCommand):
                     self.open_scheme(paths[i][1])
 
             self.window.show_quick_panel(
-                choices, 
+                choices,
                 on_done,
-                selected_index = selected_index,
-                placeholder = 'Choose a color scheme to edit ...'
+                selected_index=selected_index,
+                placeholder='Choose a color scheme to edit ...'
             )
 
     @staticmethod

--- a/plugins/color_scheme_dev.py
+++ b/plugins/color_scheme_dev.py
@@ -256,16 +256,33 @@ class PackagedevEditSchemeCommand(sublime_plugin.WindowCommand):
                 (setting, self.get_scheme_path(view, setting))
                 for setting in ('dark_color_scheme', 'light_color_scheme')
             ]
+            current_os_mode = sublime.ui_info()['system']['style']
             choices = [
                 sublime.QuickPanelItem(setting, details=str(path), kind=KIND_SCHEME)
                 for setting, path in paths
             ]
 
+            for idx, choice in enumerate(choices):
+                if current_os_mode == 'dark' and choice.trigger == 'dark_color_scheme':
+                    choice.annotation = 'Active'
+                    selected_index = idx
+                elif current_os_mode == 'light' and choice.trigger == 'light_color_scheme':
+                    choice.annotation = 'Active'
+                    selected_index = idx
+                else:
+                    choice.annotation = ''
+                    selected_index = -1
+
             def on_done(i):
                 if i >= 0:
                     self.open_scheme(paths[i][1])
 
-            self.window.show_quick_panel(choices, on_done)
+            self.window.show_quick_panel(
+                choices, 
+                on_done,
+                selected_index = selected_index,
+                placeholder = 'Choose a color scheme to edit ...'
+            )
 
     @staticmethod
     def get_scheme_path(view, setting_name):

--- a/plugins/color_scheme_dev.py
+++ b/plugins/color_scheme_dev.py
@@ -262,16 +262,11 @@ class PackagedevEditSchemeCommand(sublime_plugin.WindowCommand):
                 for setting, path in paths
             ]
 
+            selected_index = -1
             for idx, choice in enumerate(choices):
-                if current_os_mode == 'dark' and choice.trigger == 'dark_color_scheme':
+                if choice.trigger.startswith(current_os_mode):
                     choice.annotation = 'Active'
                     selected_index = idx
-                elif current_os_mode == 'light' and choice.trigger == 'light_color_scheme':
-                    choice.annotation = 'Active'
-                    selected_index = idx
-                else:
-                    choice.annotation = ''
-                    selected_index = -1
 
             def on_done(i):
                 if i >= 0:

--- a/plugins/theme_dev.py
+++ b/plugins/theme_dev.py
@@ -50,12 +50,28 @@ class PackagedevEditThemeCommand(sublime_plugin.WindowCommand):
                 )
                 for setting in ('dark_theme', 'light_theme')
             ]
+            current_os_mode = sublime.ui_info()['system']['style']
+            for idx, choice in enumerate(choices):
+                if current_os_mode == 'dark' and choice.trigger == 'dark_theme':
+                    choice.annotation = 'Active'
+                    selected_index = idx
+                elif current_os_mode == 'light' and choice.trigger == 'light_theme':
+                    choice.annotation = 'Active'
+                    selected_index = idx
+                else:
+                    choice.annotation = ''
+                    selected_index = -1
 
             def on_done(i):
                 if i >= 0:
                     self.open_theme(choices[i].details)
 
-            self.window.show_quick_panel(choices, on_done)
+            self.window.show_quick_panel(
+                choices, 
+                on_done,
+                selected_index = selected_index,
+                placeholder = "Choose a theme to edit ..."
+            )
 
     def open_theme(self, theme_name):
         theme_path = ResourcePath(sublime.find_resources(theme_name)[0])

--- a/plugins/theme_dev.py
+++ b/plugins/theme_dev.py
@@ -50,17 +50,13 @@ class PackagedevEditThemeCommand(sublime_plugin.WindowCommand):
                 )
                 for setting in ('dark_theme', 'light_theme')
             ]
+
             current_os_mode = sublime.ui_info()['system']['style']
+            selected_index = -1
             for idx, choice in enumerate(choices):
-                if current_os_mode == 'dark' and choice.trigger == 'dark_theme':
+                if choice.trigger.startswith(current_os_mode):
                     choice.annotation = 'Active'
                     selected_index = idx
-                elif current_os_mode == 'light' and choice.trigger == 'light_theme':
-                    choice.annotation = 'Active'
-                    selected_index = idx
-                else:
-                    choice.annotation = ''
-                    selected_index = -1
 
             def on_done(i):
                 if i >= 0:

--- a/plugins/theme_dev.py
+++ b/plugins/theme_dev.py
@@ -67,10 +67,10 @@ class PackagedevEditThemeCommand(sublime_plugin.WindowCommand):
                     self.open_theme(choices[i].details)
 
             self.window.show_quick_panel(
-                choices, 
+                choices,
                 on_done,
-                selected_index = selected_index,
-                placeholder = "Choose a theme to edit ..."
+                selected_index=selected_index,
+                placeholder="Choose a theme to edit ..."
             )
 
     def open_theme(self, theme_name):


### PR DESCRIPTION
This PR adds the ability to make editing color schemes/themes OS aware, when the corresponding settings are set to `auto`. The quick panel item that is active is selected and has an annotation of `Active` based on the OS appearance mode. 

Resolves #329 