### PR TITLE
[ST4] Add a few missing color scheme global keys. 

### DIFF
--- a/Package/Sublime Text Color Scheme/Completions/Globals Keys (in-string).sublime-completions
+++ b/Package/Sublime Text Color Scheme/Completions/Globals Keys (in-string).sublime-completions
@@ -167,6 +167,16 @@
             "kind": ["keyword", "k", "globals"],
         },
         {
+            "trigger": "scroll_highlight",
+            "details": "Search results color on scroll bar",
+            "kind": ["keyword", "k", "globals"],
+        },
+        {
+            "trigger": "scroll_selected_highlight",
+            "details": "Search results color of selected on scroll bar",
+            "kind": ["keyword", "k", "globals"],
+        },
+        {
             "trigger": "selection",
             "details": "Selection color",
             "kind": ["keyword", "k", "globals"],

--- a/Package/Sublime Text Color Scheme/Completions/Globals Keys (in-string).sublime-completions
+++ b/Package/Sublime Text Color Scheme/Completions/Globals Keys (in-string).sublime-completions
@@ -82,6 +82,11 @@
             "kind": ["keyword", "k", "globals"],
         },
         {
+            "trigger": "gutter_foreground_highlight",
+            "details": "Gutter foreground highlighted color",
+            "kind": ["keyword", "k", "globals"],
+        },
+        {
             "trigger": "highlight",
             "details": "Border color of inactive search results",
             "kind": ["keyword", "k", "globals"],

--- a/Package/Sublime Text Color Scheme/Completions/Globals Keys.sublime-completions
+++ b/Package/Sublime Text Color Scheme/Completions/Globals Keys.sublime-completions
@@ -224,6 +224,18 @@
             "kind": ["keyword", "k", "globals"],
         },
         {
+            "trigger": "scroll_highlight",
+            "details": "Search results color on scroll bar",
+            "contents": "\"scroll_highlight\": \"$1\",",
+            "kind": ["keyword", "k", "globals"],
+        },
+        {
+            "trigger": "scroll_selected_highlight",
+            "details": "Search results color of selected on scroll bar",
+            "contents": "\"scroll_selected_highlight\": \"$1\",",
+            "kind": ["keyword", "k", "globals"],
+        },
+        {
             "trigger": "selection",
             "details": "Selection color",
             "contents": "\"selection\": \"$1\",",

--- a/Package/Sublime Text Color Scheme/Completions/Globals Keys.sublime-completions
+++ b/Package/Sublime Text Color Scheme/Completions/Globals Keys.sublime-completions
@@ -122,6 +122,12 @@
             "kind": ["keyword", "k", "globals"],
         },
         {
+            "trigger": "gutter_foreground_highlight",
+            "details": "Gutter foreground highlighted color",
+            "contents": "\"gutter_foreground_highlight\": \"$1\",",
+            "kind": ["keyword", "k", "globals"],
+        },
+        {
             "trigger": "highlight",
             "details": "Border color of inactive search results",
             "contents": "\"highlight\": \"$1\",",

--- a/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-syntax
+++ b/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-syntax
@@ -231,7 +231,7 @@ contexts:
           |stack_guide|active_guide|guide
           |misspelling
           |brackets_foreground|bracket_contents_foreground|tags_foreground
-          |minimap_border|gutter|gutter_foreground|rulers|fold_marker
+          |minimap_border|gutter(?:_(?:foreground|foreground_highlight))?|rulers|fold_marker
           |line_diff_(?:modified|added|deleted) # added in 3186 & 3189
           |block_caret(?:_(?:border|underline))? # block_caret added in 3190, others in 4086.
         )(")

--- a/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-syntax
+++ b/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-syntax
@@ -232,6 +232,7 @@ contexts:
           |misspelling
           |brackets_foreground|bracket_contents_foreground|tags_foreground
           |minimap_border|gutter(?:_(?:foreground|foreground_highlight))?|rulers|fold_marker
+          |scroll_(?:highlight|selected_highlight)
           |line_diff_(?:modified|added|deleted) # added in 3186 & 3189
           |block_caret(?:_(?:border|underline))? # block_caret added in 3190, others in 4086.
         )(")


### PR DESCRIPTION
This PR adds the following missing global keys to the completions and syntax file for appropriate highlighting.
1. `gutter_foreground_highlight`.
2. `scroll_highlight`
3. `scroll_selected_highlight` 

These are documented in https://www.sublimetext.com/docs/color_schemes.html#global_settings:ver-dev