### PR TITLE
Commands: Add support for the platform key

### DIFF
--- a/Package/Sublime Text Commands/Completions/Platform Names.sublime-completions
+++ b/Package/Sublime Text Commands/Completions/Platform Names.sublime-completions
@@ -1,0 +1,17 @@
+{
+    "scope": "meta.platform-name.sublime-commands",
+    "completions": [
+        {
+            "trigger": "Linux",
+            "kind": ["snippet", "p", "Platform"],
+        },
+        {
+            "trigger": "OSX",
+            "kind": ["snippet", "p", "Platform"],
+        },
+        {
+            "trigger": "Windows",
+            "kind": ["snippet", "p", "Platform"],
+        },
+    ]
+}

--- a/Package/Sublime Text Commands/Sublime Text Commands.sublime-syntax
+++ b/Package/Sublime Text Commands/Sublime Text Commands.sublime-syntax
@@ -93,7 +93,7 @@ contexts:
       scope: punctuation.definition.string.begin.json
       set:
         - meta_scope: meta.platform-name.sublime-commands string.quoted.double.json
-        - meta_content_scope: invalid.illegal.invalid-command.sublime-commands
+        - meta_content_scope: invalid.illegal.invalid-platform.sublime-commands
         - match: \"
           scope: punctuation.definition.string.end.json
           pop: true

--- a/Package/Sublime Text Commands/Sublime Text Commands.sublime-syntax
+++ b/Package/Sublime Text Commands/Sublime Text Commands.sublime-syntax
@@ -114,6 +114,12 @@ contexts:
   expect-colon:
     - include: Sublime JSON.sublime-syntax#expect-colon
 
+  expect-string-rest:
+    - include: Sublime JSON.sublime-syntax#expect-string-rest
+
+  string-escape:
+    - include: Sublime JSON.sublime-syntax#string-escape
+
   expect-string-value:
     - include: Sublime JSON.sublime-syntax#expect-string-value
 

--- a/Package/Sublime Text Commands/Sublime Text Commands.sublime-syntax
+++ b/Package/Sublime Text Commands/Sublime Text Commands.sublime-syntax
@@ -60,6 +60,13 @@ contexts:
         2: keyword.other.main.sublime-commands
         3: punctuation.definition.string.end.json
       set: [expect-mapping-value, expect-colon]
+    - match: (")(platform)(")
+      scope: meta.mapping.key.json meta.main-key.sublime-commands string.quoted.double.json
+      captures:
+        1: punctuation.definition.string.begin.json
+        2: keyword.other.main.sublime-commands
+        3: punctuation.definition.string.end.json
+      set: [expect-platform-string-value, expect-colon]
     - match: (")(\w*)(")
       scope: meta.mapping.key.json meta.main-key.sublime-commands string.quoted.double.json
       captures:
@@ -67,6 +74,33 @@ contexts:
         # 2: invalid.unknown-key.sublime-commands
         3: punctuation.definition.string.end.json
       set: [expect-any-value, expect-colon]
+
+  expect-platform-string-value:
+    - match: (?=")
+      set: [mapping-value-meta, platform-name-string-pop]
+    - include: expect-string-rest
+
+  platform-name-string-pop:
+    - match: (\")(!)?(Windows|Linux|OSX)(\")
+      scope: meta.platform-name.sublime-commands string.quoted.double.json
+      captures:
+        1: punctuation.definition.string.begin.json
+        2: keyword.operator.logical.sublime-commands
+        3: support.constant.command-name.sublime-commands
+        4: punctuation.definition.string.end.json
+      pop: true
+    - match: \" # probably illegal command name
+      scope: punctuation.definition.string.begin.json
+      set:
+        - meta_scope: meta.platform-name.sublime-commands string.quoted.double.json
+        - meta_content_scope: invalid.illegal.invalid-command.sublime-commands
+        - match: \"
+          scope: punctuation.definition.string.end.json
+          pop: true
+        - include: string-escape
+        - match: $\n?
+          scope: invalid.illegal.unclosed-string.json
+          pop: true
 
   expect-command-name-value:
     - include: Sublime JSON.sublime-syntax#expect-command-name-value
@@ -106,3 +140,9 @@ contexts:
 
   expect-key-rest:
     - include: Sublime JSON.sublime-syntax#expect-key-rest
+
+  mapping-value-meta:
+    - clear_scopes: 1
+    - meta_scope: meta.mapping.value.json
+    - match: ''
+      pop: true

--- a/Package/Sublime Text Commands/Sublime Text Commands.sublime-syntax
+++ b/Package/Sublime Text Commands/Sublime Text Commands.sublime-syntax
@@ -89,7 +89,7 @@ contexts:
         3: support.constant.command-name.sublime-commands
         4: punctuation.definition.string.end.json
       pop: true
-    - match: \" # probably illegal command name
+    - match: \"
       scope: punctuation.definition.string.begin.json
       set:
         - meta_scope: meta.platform-name.sublime-commands string.quoted.double.json

--- a/Package/Sublime Text Commands/syntax_test_commands.json
+++ b/Package/Sublime Text Commands/syntax_test_commands.json
@@ -25,7 +25,7 @@
 // ^^^^^ meta.mapping.key.json meta.main-key.sublime-commands string.quoted.double.json
 //  ^^^ - keyword.other.main.sublime-commands
 //        ^^^^^ meta.mapping.value.json string.quoted.double.json
-        "args": {"setting": "word_wrap"}
+        "args": {"setting": "word_wrap"},
 //      ^^^^^^ meta.mapping.key.json meta.main-key.sublime-commands string.quoted.double.json
 //       ^^^^ keyword.other.main.sublime-commands
 //            ^ punctuation.separator.mapping.key-value.json
@@ -35,6 +35,16 @@
 //               ^^^^^^^^^ meta.mapping.value.json meta.mapping.key.json string.quoted.double.json
 //                        ^ punctuation.separator.mapping.key-value.json
 //                          ^^^^^^^^^^^ meta.mapping.value.json meta.mapping.value.json string.quoted.double.json
+    "platform": "!Windows"
+//  ^^^^^^^^^^ meta.mapping.key.json meta.main-key.sublime-commands string.quoted.double.json
+//  ^ punctuation.definition.string.begin.json
+//   ^^^^^^^^ keyword.other.main.sublime-commands
+//            ^ punctuation.separator.mapping.key-value.json
+//              ^^^^^^^^^^ meta.mapping.value.json meta.platform-name.sublime-commands string.quoted.double.json
+//              ^ punctuation.definition.string.begin.json
+//               ^ keyword.operator.logical.sublime-commands
+//                ^^^^^^^ support.constant.command-name.sublime-commands
+//                       ^ punctuation.definition.string.end.json
     },
 
     abc

--- a/Package/Sublime Text Menu/Sublime Text Menu.sublime-syntax
+++ b/Package/Sublime Text Menu/Sublime Text Menu.sublime-syntax
@@ -140,7 +140,7 @@ contexts:
       scope: punctuation.definition.string.begin.json
       set:
         - meta_scope: meta.platform-name.sublime-menu string.quoted.double.json
-        - meta_content_scope: invalid.illegal.invalid-command.sublime-menu
+        - meta_content_scope: invalid.illegal.invalid-platform.sublime-menu
         - match: \"
           scope: punctuation.definition.string.end.json
           pop: true

--- a/Package/Sublime Text Menu/Sublime Text Menu.sublime-syntax
+++ b/Package/Sublime Text Menu/Sublime Text Menu.sublime-syntax
@@ -136,7 +136,7 @@ contexts:
         3: support.constant.command-name.sublime-menu
         4: punctuation.definition.string.end.json
       pop: true
-    - match: \" # probably illegal command name
+    - match: \"
       scope: punctuation.definition.string.begin.json
       set:
         - meta_scope: meta.platform-name.sublime-menu string.quoted.double.json


### PR DESCRIPTION
This PR

1. Adds support for the `platform` key in `.sublime-commands` introduced in Build 4094 to support platform specific entries in the command palette.
2. Added completions for `platform` names.

This is essentially just a copy of what exists for the `.sublime-menu` file (Both the contexts and the completions). Maybe we need a way to reuse them ?