### PR TITLE
[ST4] Sync the in string completions to that of global keys completions for color scheme.

### DIFF
--- a/Package/Sublime Text Color Scheme/Completions/Globals Keys (in-string).sublime-completions
+++ b/Package/Sublime Text Color Scheme/Completions/Globals Keys (in-string).sublime-completions
@@ -22,6 +22,26 @@
             "kind": ["keyword", "k", "globals"],
         },
         {
+            "trigger": "block_caret_corner_style",
+            "details": "Block caret corner style",
+            "kind": ["keyword", "k", "globals"],
+        },
+        {
+            "trigger": "block_caret_border",
+            "details": "Block caret border color",
+            "kind": ["keyword", "k", "globals"],
+        },
+        {
+            "trigger": "block_caret_underline",
+            "details": "Color of the block caret in selection",
+            "kind": ["keyword", "k", "globals"],
+        },
+        {
+            "trigger": "block_caret_corner_radius",
+            "details": "Block caret corner radius",
+            "kind": ["keyword", "k", "globals"],
+        },        
+        {
             "trigger": "bracket_contents_foreground",
             "details": "Foreground color of highlighted brackets (inside)",
             "kind": ["keyword", "k", "globals"],


### PR DESCRIPTION
This PR syncs the `Globals Keys (in-string).sublime-completions` to that of `Globals Keys.sublime-completions`.

Some of the missing keys were:
1. `block_caret_corner_style`
2. `block_caret_border`
3. `block_caret_underline`
4. `block_caret_corner_radius`

These were added in ac80cf7d9d681677b023d21d146143ef68f2c0c8 but looks like I forgot to add them to string completions.