### PR TITLE
Remove the use of deprecated API endpoints.

### DIFF
--- a/Package/Sublime Text Commands/Completions/Main Keys (in-string).sublime-completions
+++ b/Package/Sublime Text Commands/Completions/Main Keys (in-string).sublime-completions
@@ -17,5 +17,10 @@
             "details": "Command argumnts",
             "kind": ["keyword", "k", "main"],
         },
+        {
+            "trigger": "platform",
+            "details": "Platform name",
+            "kind": ["keyword", "k", "main"],
+        }
     ]
 }

--- a/Package/Sublime Text Commands/Completions/Main Keys.sublime-completions
+++ b/Package/Sublime Text Commands/Completions/Main Keys.sublime-completions
@@ -13,6 +13,12 @@
             "details": "Command name",
             "kind": ["keyword", "k", "main"],
         },
+        {
+            "trigger": "platform",
+            "contents": "\"platform\": \"$1\",$0",
+            "details": "Platform name",
+            "kind": ["keyword", "k", "main"],
+        }
         // args provided by plugin
     ]
 }

--- a/plugins/file_conversion.py
+++ b/plugins/file_conversion.py
@@ -253,5 +253,5 @@ class PackagedevConvertCommand(sublime_plugin.WindowCommand):
                                      {'save': True, '_output_text': output_text})
 
     def status(self, msg, file_path=None):
-        sublime.status_message(msg)
+        self.window.status_message(msg)
         print("[PackageDev] " + msg + (" (%s)" % file_path if file_path is not None else ""))

--- a/plugins/new_resource_file/__init__.py
+++ b/plugins/new_resource_file/__init__.py
@@ -69,7 +69,7 @@ class PackagedevNewResourceCommand(sublime_plugin.WindowCommand):
         v = self.window.new_file()
 
         # initialize settings (and syntax)
-        v.set_syntax_file(_syntax_path_for_kind(kind))
+        v.assign_syntax(_syntax_path_for_kind(kind))
         v.settings().set('default_dir', package_dir)
         name, extension = _default_file_name(kind, suffix, package_name)
         if name:

--- a/plugins/snippet_dev.py
+++ b/plugins/snippet_dev.py
@@ -40,7 +40,7 @@ class PackagedevSnippetFromRawSnippetCommand(sublime_plugin.TextCommand):
         _insert_unindented(self.view, content)
         self.view.run_command('next_field')
 
-        self.view.set_syntax_file(syntax_paths.SNIPPET)
+        self.view.assign_syntax(syntax_paths.SNIPPET)
 
 
 class PackagedevRawSnippetFromSnippetCommand(sublime_plugin.TextCommand):
@@ -53,5 +53,5 @@ class PackagedevRawSnippetFromSnippetCommand(sublime_plugin.TextCommand):
         content = content.replace("]]$UNDEFINED>", "]]>")  # undo defusing
 
         v = self.view.window().new_file()
-        v.set_syntax_file(syntax_paths.SNIPPET_RAW)
+        v.assign_syntax(syntax_paths.SNIPPET_RAW)
         _insert_unindented(v, content)

--- a/plugins/syntax_dev/completions.py
+++ b/plugins/syntax_dev/completions.py
@@ -235,6 +235,7 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
 
     def _complete_scope(self, prefix, locations):
         # Determine entire prefix
+        window = self.view.window()
         prefixes = set()
         for point in locations:
             *_, real_prefix = self._line_prefix(point).rpartition(" ")
@@ -257,12 +258,15 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
         for i, token in enumerate(tokens[:-1]):
             node = nodes.find(token)
             if not node:
-                status("`%s` not found in scope naming conventions" % '.'.join(tokens[:i + 1]))
+                status(
+                    "`%s` not found in scope naming conventions" % '.'.join(tokens[:i + 1]),
+                    window
+                )
                 break
             nodes = node.children
             if not nodes:
                 status("No nodes available in scope naming conventions after `%s`"
-                       % '.'.join(tokens[:-1]))
+                       % '.'.join(tokens[:-1]), window)
                 break
         else:
             # Offer to complete from conventions or base scope
@@ -273,9 +277,14 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
         return base_scope_completion
 
     def _complete_base_scope(self, last_token):
+        window = self.view.window()
         regions = self.view.find_by_selector("meta.scope string - meta.block")
         if len(regions) != 1:
-            status("Warning: Could not determine base scope uniquely", console=True)
+            status(
+                "Warning: Could not determine base scope uniquely",
+                window,
+                console=True
+            )
             self.base_suffix = None
             return []
 

--- a/plugins/syntax_dev_legacy.py
+++ b/plugins/syntax_dev_legacy.py
@@ -25,9 +25,9 @@ __all__ = (
 PACKAGE_NAME = __package__.split('.')[0]
 
 
-def status(msg, console=False):
+def status(msg, window, console=False):
     msg = "[%s] %s" % (PACKAGE_NAME, msg)
-    sublime.status_message(msg)
+    window.status_message(msg)
     if console:
         print(msg)
 

--- a/plugins/syntax_dev_legacy.py
+++ b/plugins/syntax_dev_legacy.py
@@ -192,6 +192,9 @@ class PackagedevRearrangeYamlSyntaxDefCommand(sublime_plugin.TextCommand):
                 Forwarded to yaml.dump (if they are valid).
         """
         # Check the environment (view, args, ...)
+
+        window = self.view.window()
+
         if self.view.is_scratch():
             return
         if self.view.is_loading():
@@ -255,7 +258,7 @@ class PackagedevRearrangeYamlSyntaxDefCommand(sublime_plugin.TextCommand):
 
             if not text:
                 output.print("Error re-dumping the data in file (no output).")
-                status("Error re-dumping the data (no output).", True)
+                status("Error re-dumping the data (no output).", window, True)
                 return
 
             # Replace the whole buffer (with default options)
@@ -333,6 +336,9 @@ class LegacySyntaxDefCompletions(sublime_plugin.EventListener):
 
     def on_query_completions(self, view, prefix, locations):
         # We can't work with multiple selections here
+
+        window = view.window()
+
         if len(locations) > 1:
             return []
 
@@ -372,8 +378,11 @@ class LegacySyntaxDefCompletions(sublime_plugin.EventListener):
                     for i, token in enumerate(tokens):
                         node = nodes.find(token)
                         if not node:
-                            status("Warning: `%s` not found in scope naming conventions"
-                                   % '.'.join(tokens[:i + 1]))
+                            status(
+                                "Warning: `%s` not found in scope naming conventions"
+                                % '.'.join(tokens[:i + 1]),
+                                window
+                            )
                             break
                         nodes = node.children
                         if not nodes:
@@ -383,11 +392,11 @@ class LegacySyntaxDefCompletions(sublime_plugin.EventListener):
                         return inhibit(nodes.to_completion())
                     else:
                         status("No nodes available in scope naming conventions after `%s`"
-                               % '.'.join(tokens))
+                               % '.'.join(tokens), window)
                         # Search for the base scope appendix/suffix
                         regs = view.find_by_selector("meta.scope-name meta.value string")
                         if not regs:
-                            status("Warning: Could not find base scope")
+                            status("Warning: Could not find base scope", window)
                             return []
 
                         base_scope = view.substr(regs[0]).strip("\"'")
@@ -422,7 +431,10 @@ class LegacySyntaxDefCompletions(sublime_plugin.EventListener):
 
             variables = [view.substr(r)
                          for r in view.find_by_selector("variable.other.repository-key")]
-            status("Found %d local repository keys to be used in includes" % len(variables))
+            status(
+                "Found %d local repository keys to be used in includes" % len(variables),
+                window
+            )
             return inhibit(zip(variables, variables))
 
         # Do not bother if the syntax def already matched the current position,


### PR DESCRIPTION
This PR

1. Makes use of `Window.status_message` instead of `sublime.status_message`.
2. Uses `View.assign_syntax` instead of `View.set_syntax_file` (which uses `assign_syntax` internally).
3. I did not find any instances of usage of `Window.get_output_panel` apart from that in comments.

PS: I have also slipped in a commit to add completions for the `platform` key which was added in 3f858fd7997a8dd3ff85d5ac63584214983542ea (which I unfortunately forgot to add, but did not seem well worth a seperate PR).

Resolves #336 