### PR TITLE
Trim redundant prefixes of syntax test suggestions.

### DIFF
--- a/Package/PackageDev.sublime-settings
+++ b/Package/PackageDev.sublime-settings
@@ -31,6 +31,10 @@
     // then suggest meta.example.markdown (true) vs meta.example (false).
     "syntax_test.suggest_scope_suffix": true,
 
+    // Whether to trim leading scopes from suggestions
+    // that are already part of previous assertions.
+    "syntax_test.suggest_trimmed_prefix": false,
+
 
     /// ADVANCED SETTINGS /////////////////////////////////////////////////////////////////////////
 

--- a/plugins/syntaxtest_dev.py
+++ b/plugins/syntaxtest_dev.py
@@ -352,6 +352,22 @@ class PackagedevSuggestSyntaxTestCommand(sublime_plugin.TextCommand):
         suggest_suffix = get_setting('syntax_test.suggest_scope_suffix', True)
         scope = find_common_scopes(scopes, not suggest_suffix)
 
+        trim_prefix = get_setting('syntax_test.suggest_trimmed_prefix', False)
+        if trim_prefix:
+            above_scopes = [
+                self.view.substr(sublime.Region(
+                    line.line_region.begin() + line.assertion_colrange[1],
+                    line.line_region.end(),
+                )).strip()
+                for line in lines[1:]
+                if line.assertion_colrange[0] <= lines[0].assertion_colrange[0]
+                and line.assertion_colrange[1] >= lines[0].assertion_colrange[1]
+            ]
+
+            for above_scope in reversed(above_scopes):
+                if scope.startswith(above_scope):
+                    scope = scope[len(above_scope):].strip()
+
         # delete the existing selection
         if not view.sel()[0].empty():
             view.erase(edit, view.sel()[0])

--- a/plugins/syntaxtest_dev.py
+++ b/plugins/syntaxtest_dev.py
@@ -365,8 +365,17 @@ class PackagedevSuggestSyntaxTestCommand(sublime_plugin.TextCommand):
             ]
 
             for above_scope in reversed(above_scopes):
-                if scope.startswith(above_scope):
-                    scope = scope[len(above_scope):].strip()
+                score = sublime.score_selector(scope, above_scope)
+                if score > 0:
+                    scope_parts = scope.split(' ')
+                    matched_count = -(-score.bit_length() // 3) - 1
+
+                    score_of_last_part = score >> matched_count*3
+                    maximum_possible_score_of_last_part = len(scope_parts[matched_count - 1].split('.'))
+                    if score_of_last_part != maximum_possible_score_of_last_part:
+                        matched_count -= 1
+
+                    scope = ' '.join(scope_parts[matched_count:])
 
         # delete the existing selection
         if not view.sel()[0].empty():

--- a/plugins/syntaxtest_dev.py
+++ b/plugins/syntaxtest_dev.py
@@ -370,9 +370,9 @@ class PackagedevSuggestSyntaxTestCommand(sublime_plugin.TextCommand):
                     scope_parts = scope.split(' ')
                     matched_count = -(-score.bit_length() // 3) - 1
 
-                    score_of_last_part = score >> matched_count*3
-                    maximum_possible_score_of_last_part = len(scope_parts[matched_count - 1].split('.'))
-                    if score_of_last_part != maximum_possible_score_of_last_part:
+                    score_of_last_part = score >> matched_count * 3
+                    possible_score_of_last_part = len(scope_parts[matched_count - 1].split('.'))
+                    if score_of_last_part != possible_score_of_last_part:
                         matched_count -= 1
 
                     scope = ' '.join(scope_parts[matched_count:])


### PR DESCRIPTION
The implementation isn't necessarily final, but feedback would be appreciated.

First, a motivating example. The pipe denotes the cursor, and `syntax_test.suggest_scope_suffix` is false.

Before:

```js
    if ( true ) { }
//  ^^^^^^^^^^^^^^^ meta.conditional
//  ^^ keyword.control.conditional.if
//     |
```

Ordinary result of typing `^`:

```js
    if ( true ) { }
//  ^^^^^^^^^^^^^^^ meta.conditional
//  ^^ keyword.control.conditional.if
//     ^ meta.conditional meta.group punctuation.section.group.begin|
```

With `"syntax_test.suggest_trimmed_prefix": true`:

```js
    if ( true ) { }
//  ^^^^^^^^^^^^^^^ meta.conditional
//  ^^ keyword.control.conditional.if
//     ^ meta.group punctuation.section.group.begin|
```

---

The implementation is a first pass, but it's probably mostly correct. Notes:

- The setting name is off the top of my head and could be changed.
- It might be neater to add an `assertion_scopes` property to `AssertionLineDetails` rather than re-extracting that in the new code.
- The code assumes that assertions in previous lines are ordered. This should probably be changed.