### PR TITLE
removed '#' from word_separators

### DIFF
--- a/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-settings
+++ b/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-settings
@@ -5,5 +5,5 @@
         { "selector": "meta.mapping.key punctuation.definition.string.begin" },
     ],
     "extensions": ["sublime-color-scheme"],
-    "word_separators": "./\\()\"':,.;<>~!@#$%^&*|+=[]{}`~?" // default without '-'
+    "word_separators": "./\\()\"':,.;<>~!@$%^&*|+=[]{}`~?" // default without '-' and '#'
 }


### PR DESCRIPTION
This will allow users to select an entire hex designation (`#AABBCC`) rather than just the alphanumeric part (`AABBCC`).