### PR TITLE
Fix syntax test tab dialog appearing on navigating test files using `Goto Anything`.

### DIFF
--- a/plugins/syntaxtest_dev.py
+++ b/plugins/syntaxtest_dev.py
@@ -431,6 +431,14 @@ class AssignSyntaxTestSyntaxListener(sublime_plugin.EventListener):
         test_header = get_syntax_test_tokens(view)
         if not test_header:
             return
+
+        # If the user navigates through syntax test files using Goto Anything,
+        # then the navigation is disrupted (because of the dialog) if the test
+        # files happens to use indentation. So, we just skip checking any files
+        # that are transiently opened by using Goto Anything.
+        if view.sheet().is_transient():
+            return
+
         current_syntax = view.settings().get('syntax', None)
         test_syntax = test_header.syntax_file
 


### PR DESCRIPTION
This PR fixes a situation where navigating syntax test files using `Goto Anything` can be disruptive. Since the view is loaded and PD throws the dialog for those files that use tabs in test files, this results in a bad UX.

To prevent this, we simply skip files that are transiently loaded when navigating `Goto Anything`.

Fixes #350, fixes #177 