### PR TITLE
Add a way to enable/disable the settings quick edit (pencil) icon.

### DIFF
--- a/Package/PackageDev.sublime-settings
+++ b/Package/PackageDev.sublime-settings
@@ -26,6 +26,10 @@
     // Each theme containing one of the list's strings is hidden.
     "settings.exclude_theme_patterns": [],
 
+    // Whether to enable the edit settings pencil icon. Close & reopen the 
+    // settings file for this to take effect.
+    "settings.enable_quick_edit_icon": true,
+
     // Whether or not to keep the scope suffix in the suggested test scopes
     // i.e. if the base scope is text.html.markdown
     // then suggest meta.example.markdown (true) vs meta.example (false).

--- a/plugins/settings/__init__.py
+++ b/plugins/settings/__init__.py
@@ -145,7 +145,7 @@ class SettingsListener(sublime_plugin.ViewEventListener):
             logger.error("Not a Sublime Text Settings or Project file: %r", filepath)
 
         self.phantom_set = sublime.PhantomSet(self.view, "sublime-settings-edit")
-        if self._is_base_settings_view():
+        if self._is_base_settings_view() and get_setting("settings.enable_quick_edit_icon"):
             self.build_phantoms()
 
     def __del__(self):
@@ -156,7 +156,7 @@ class SettingsListener(sublime_plugin.ViewEventListener):
     def on_modified_async(self):
         """Sublime Text modified event handler to update linting."""
         self.do_linting()
-        if self._is_base_settings_view():
+        if self._is_base_settings_view() and get_setting("settings.enable_quick_edit_icon"):
             # This may only occur for unpacked packages
             self.build_phantoms()
 


### PR DESCRIPTION
This PR adds an additional setting `settings.enable_quick_edit_icon`, that will allow the user to control whether they want to see & use PD's quick edit settings icon.

It took quite some time to understand where the setting `edit_settings_view` was being applied to base setting view, since PD itself did not seem to do it. After some digging, it's actually being applied by `Default/settings.py`. Just for posterity.

Fixes #334 