### PR TITLE
Update color scheme word_separators, change LICENSE year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-Copyright (c) 2010-2014 Guillermo López-Anglada (Vintageous)
-Copyright (c) 2012-2019 FichteFoll <fichtefoll2@googlemail.com>
+Copyright (c) 2010-2014 Guillermo LÃ³pez-Anglada (Vintageous)
+Copyright (c) 2012-2021 FichteFoll <fichtefoll2@googlemail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-settings
+++ b/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-settings
@@ -5,5 +5,5 @@
         { "selector": "meta.mapping.key punctuation.definition.string.begin" },
     ],
     "extensions": ["sublime-color-scheme"],
-    "word_separators": "./\\()\"':,.;<>~!@$%^&*|+=[]{}`~?" // default without '-'
+    "word_separators": "./\\()\"':,.;<>~!@$%^&*|+=[]{}`~?" // default without '-' and '#'
 }

--- a/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-settings
+++ b/Package/Sublime Text Color Scheme/Sublime Text Color Scheme.sublime-settings
@@ -5,5 +5,5 @@
         { "selector": "meta.mapping.key punctuation.definition.string.begin" },
     ],
     "extensions": ["sublime-color-scheme"],
-    "word_separators": "./\\()\"':,.;<>~!@#$%^&*|+=[]{}`~?" // default without '-'
+    "word_separators": "./\\()\"':,.;<>~!@$%^&*|+=[]{}`~?" // default without '-'
 }


### PR DESCRIPTION
I removed `#` from the color scheme `word_separators` so hex colors can be completely selected on double-click. I also updated the year in the `LICENSE` to 2021. This will need to be changed again in 2 months. Maybe somebody can write an action for that...