### PR TITLE
Fix syntax definition automatic assignment for syntax test files

### DIFF
--- a/plugins/syntaxtest_dev.py
+++ b/plugins/syntaxtest_dev.py
@@ -428,6 +428,13 @@ class AssignSyntaxTestSyntaxListener(sublime_plugin.EventListener):
     PLAIN_TEXT = "Packages/Text/Plain text.tmLanguage"
 
     def on_load(self, view):
+        if view.size() == 0 and view.file_name().startswith(sublime.packages_path() + '/'):
+            sublime.set_timeout(lambda: self.assign_syntax(view), 100)
+            return
+
+        self.assign_syntax(view)
+
+    def assign_syntax(self, view):
         test_header = get_syntax_test_tokens(view)
         if not test_header:
             return
@@ -447,7 +454,7 @@ class AssignSyntaxTestSyntaxListener(sublime_plugin.EventListener):
                 view.assign_syntax(self.PLAIN_TEXT)
 
         # just base name specified
-        elif not current_syntax.endswith(test_syntax):
+        elif not current_syntax.endswith('/' + test_syntax):
             syntax_candidates = sublime.find_resources(test_syntax)
             if syntax_candidates:
                 logger.debug("Found the following candidates for %r: %r",

--- a/plugins/syntaxtest_dev.py
+++ b/plugins/syntaxtest_dev.py
@@ -430,9 +430,8 @@ class AssignSyntaxTestSyntaxListener(sublime_plugin.EventListener):
     def on_load(self, view):
         if view.size() == 0 and view.file_name().startswith(sublime.packages_path() + '/'):
             sublime.set_timeout(lambda: self.assign_syntax(view), 100)
-            return
-
-        self.assign_syntax(view)
+        else:
+            self.assign_syntax(view)
 
     def assign_syntax(self, view):
         test_header = get_syntax_test_tokens(view)


### PR DESCRIPTION
This fixes the bug whereby opening a `syntax_test_` file from `OverrideAudit: Open Resource` etc. would open without the syntax being assigned automatically from the syntax test header line.

The `on_load` event listener is fired before the file was read from the `.sublime-package` file, meaning the view is still empty, causing it to miss the syntax test header. So, this commit changes the behavior so that, if it sees that the file being loaded resides within the package catalog, and is empty, then it will re-try after a short delay.