### PR TITLE
Changed value of `layer.draw_center` to `false`

### DIFF
--- a/Package/Sublime Text Theme/Completions/Rule Keys.sublime-completions
+++ b/Package/Sublime Text Theme/Completions/Rule Keys.sublime-completions
@@ -396,7 +396,7 @@
         },
         {
             "trigger": "layer.draw_center",
-            "contents": "\"layer${1:0}.draw_center\": ${0:true},",
+            "contents": "\"layer${1:0}.draw_center\": ${0:false},",
             "kind": ["keyword", "k", "property"],
         },
         {


### PR DESCRIPTION
`layer#.draw_center` defaults to `true`, it makes more sense to override it with `false`.