### PR TITLE
Don't restrict plugin reloading to Package Control Updates

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,21 +1,13 @@
-try:
-    from package_control import events
-except ImportError:
-    pass
-else:
-    if events.post_upgrade(__package__):
-        # clean up sys.modules to ensure all submodules are reloaded
-        import sys
-        prefix = __package__ + "."  # don't clear the base package
-        modules_to_clear = {
-            module_name
-            for module_name in sys.modules
-            if module_name.startswith(prefix) and module_name != __name__
-        }
+import sys
 
-        print("[{}] Cleaning up {} cached modules after update…"
-              .format(__package__, len(modules_to_clear)))
-        for module_name in modules_to_clear:
-            del sys.modules[module_name]
+# clear modules cache if package is reloaded (after update?)
+prefix = __package__ + "."  # don't clear the base package
+for module_name in [
+    module_name
+    for module_name in sys.modules
+    if module_name.startswith(prefix) and module_name != __name__
+]:
+    del sys.modules[module_name]
+prefix = None
 
 from .plugins import *  # noqa


### PR DESCRIPTION
This commit enables reloading all sub modules by just saving `main.py`.

There's no real need to restrict plugin reloading to Package Control
updates. Reloading should work properly without Package Control as well.

That strategy is already used successfully by several packages, such as
A File Icon, GitGutter, MarkdownEditing and maybe more.