### PR TITLE
Syntax: Add syntax based folding support

### DIFF
--- a/Package/Property List/Property List.sublime-syntax
+++ b/Package/Property List/Property List.sublime-syntax
@@ -78,6 +78,7 @@ contexts:
     - match: '>'
       scope: punctuation.definition.tag.end.xml
       pop: true
+    - include: tag-end-missing-pop
 
   number:
     - match: '(<)(integer)\s*(>)'
@@ -248,3 +249,10 @@ contexts:
       pop: true
     - match: '(?=\S)'
       push: any-known-element
+
+  tag-end-missing-pop:
+    # pop, if the next opening tag is following, while scoping the
+    # preceding space to give a hint about the unclosed tag
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
+      pop: 1

--- a/Package/TextMate Preferences/Completions/Settings Keys (in-key).sublime-completions
+++ b/Package/TextMate Preferences/Completions/Settings Keys (in-key).sublime-completions
@@ -75,6 +75,10 @@
 			"kind": ["snippet", "s", "setting"],
 		},
 		{
+			"trigger": "excludeTrailingNewline",
+			"kind": ["snippet", "s", "setting"],
+		},
+		{
 			"trigger": "icon",
 			"kind": ["snippet", "s", "setting"],
 		},

--- a/Package/TextMate Preferences/Completions/Settings Keys (in-key).sublime-completions
+++ b/Package/TextMate Preferences/Completions/Settings Keys (in-key).sublime-completions
@@ -63,6 +63,18 @@
 			"kind": ["snippet", "s", "setting"],
 		},
 		{
+			"trigger": "indentationFoldingEnabled",
+			"kind": ["snippet", "s", "setting"],
+		},
+		{
+			"trigger": "scopeFoldingEnabled",
+			"kind": ["snippet", "s", "setting"],
+		},
+		{
+			"trigger": "foldScopes",
+			"kind": ["snippet", "s", "setting"],
+		},
+		{
 			"trigger": "icon",
 			"kind": ["snippet", "s", "setting"],
 		},

--- a/Package/TextMate Preferences/Completions/Settings Keys.sublime-completions
+++ b/Package/TextMate Preferences/Completions/Settings Keys.sublime-completions
@@ -78,6 +78,21 @@
 			"kind": ["snippet", "s", "setting"],
 		},
 		{
+			"trigger": "indentationFoldingEnabled",
+			"contents": "<key>indentationFoldingEnabled</key>\n<false/>",
+			"kind": ["snippet", "s", "setting"],
+		},
+		{
+			"trigger": "scopeFoldingEnabled",
+			"contents": "<key>scopeFoldingEnabled</key>\n<false/>",
+			"kind": ["snippet", "s", "setting"],
+		},
+		{
+			"trigger": "foldScopes",
+			"contents": "<key>foldScopes</key>\n<array>\n\t$0\n</array>",
+			"kind": ["snippet", "s", "setting"],
+		},
+		{
 			"trigger": "icon",
 			"contents": "<key>icon</key>\n<string>$1</string>",
 			"kind": ["snippet", "s", "setting"],

--- a/Package/TextMate Preferences/Completions/Settings Keys.sublime-completions
+++ b/Package/TextMate Preferences/Completions/Settings Keys.sublime-completions
@@ -93,6 +93,11 @@
 			"kind": ["snippet", "s", "setting"],
 		},
 		{
+			"trigger": "excludeTrailingNewline",
+			"kind": ["snippet", "s", "setting"],
+			"contents": "<key>excludeTrailingNewline</key>\n<true/>",
+		},
+		{
 			"trigger": "icon",
 			"contents": "<key>icon</key>\n<string>$1</string>",
 			"kind": ["snippet", "s", "setting"],

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
@@ -68,6 +68,16 @@ contexts:
       set: end-of-array
     - include: scope:text.xml.plist#whitespace-or-tag
 
+  array-end:
+    - include: comments
+    - match: '(</)(array)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      pop: true
+
   dict-end:
     - include: comments
     - match: '(</)(dict)\s*(>)'
@@ -81,6 +91,16 @@ contexts:
   key-end:
     - include: comments
     - match: '(</)(key)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      pop: true
+
+  string-end:
+    - include: comments
+    - match: '(</)(string)\s*(>)'
       scope: meta.tag.xml
       captures:
         1: punctuation.definition.tag.begin.xml
@@ -139,6 +159,9 @@ contexts:
         - meta_scope: meta.settings-key-wrapper.tmPreferences
         - meta_content_scope: meta.inside-dict-key.plist
         - include: inside-dict-key
+        - match: 'foldScopes(?=\s*<)'
+          scope: keyword.other.foldScopes.tmPreferences
+          set: [fold-scopes, key-end]
         - match: 'shellVariables(?=\s*<)'
           scope: keyword.other.shellVariables.tmPreferences
           set: [shell-variables, key-end]
@@ -151,7 +174,7 @@ contexts:
         - match: '(?:showInSymbolList|showInIndexedSymbolList|showInIndexedReferenceList)(?=\s*<)'
           scope: entity.name.constant.setting.tmPreferences
           set: [expect-integer, key-end] # yes, integer - for some reason, booleans don't work here
-        - match: '(?:indentParens|indentSquareBrackets|preserveIndent)(?=\s*<)'
+        - match: '(?:indentParens|indentSquareBrackets|preserveIndent|indentationFoldingEnabled|scopeFoldingEnabled)(?=\s*<)'
           scope: entity.name.constant.setting.tmPreferences
           set: [expect-boolean, key-end]
         - match: 'icon(?=\s*<)'
@@ -341,6 +364,70 @@ contexts:
   regex-pattern:
     - meta_content_scope: meta.regex.tmPreferences source.regexp.oniguruma
     - include: scope:source.regexp.oniguruma
+
+  fold-scopes:
+    - include: comments
+    - match: '(<)(array)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set: inside-fold-scopes-array
+    - include: scope:text.xml.plist#whitespace-or-tag
+
+  inside-fold-scopes-array:
+    - meta_content_scope: meta.inside-array.plist
+    - include: array-end
+    - include: fold-scopes-dict
+    - include: scope:text.xml.plist#whitespace-or-tag
+
+  fold-scopes-dict:
+    - match: '(<)(dict)\s*(>)'
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      push: inside-fold-scope-dict
+
+  inside-fold-scope-dict:
+    - meta_content_scope: meta.inside-dict.foldScopes.tmPreferences
+    - include: dict-end
+    - include: fold-scope-dict-keys
+    - include: scope:text.xml.plist#whitespace-or-tag
+
+  fold-scope-dict-keys:
+    - match: '((<)(key)\s*(>))(\s*(?:begin|end)\s*)((</)(key)\s*(>))'
+      captures:
+        1: meta.tag.xml
+        2: punctuation.definition.tag.begin.xml
+        3: entity.name.tag.localname.xml
+        4: punctuation.definition.tag.end.xml
+        5: meta.inside-dict-key.plist
+        6: meta.tag.xml
+        7: punctuation.definition.tag.begin.xml
+        8: entity.name.tag.localname.xml
+        9: punctuation.definition.tag.end.xml
+      push: fold-scope-value
+
+  fold-scope-value:
+    - match: '((<)(string)\s*(>))'
+      captures:
+        1: meta.tag.xml
+        2: punctuation.definition.tag.begin.xml
+        3: entity.name.tag.localname.xml
+        4: punctuation.definition.tag.end.xml
+      set: inside-fold-scope-value
+    - match: (?=</(?:array|dict)\s*>)
+      pop: true
+    - include: scope:text.xml.plist#whitespace-or-tag
+
+  inside-fold-scope-value:
+    - meta_scope: meta.scope-name.tmPreferences
+    - include: string-end
+    - include: scope:text.xml.plist#tag-end-missing-pop
+    - include: scope:source.scope-selector
 
   shell-variables:
     - include: comments

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
@@ -410,6 +410,18 @@ contexts:
         8: entity.name.tag.localname.xml
         9: punctuation.definition.tag.end.xml
       push: fold-scope-value
+    - match: '((<)(key)\s*(>))(\s*(?:excludeTrailingNewlines)\s*)((</)(key)\s*(>))'
+      captures:
+        1: meta.tag.xml
+        2: punctuation.definition.tag.begin.xml
+        3: entity.name.tag.localname.xml
+        4: punctuation.definition.tag.end.xml
+        5: meta.inside-dict-key.plist
+        6: meta.tag.xml
+        7: punctuation.definition.tag.begin.xml
+        8: entity.name.tag.localname.xml
+        9: punctuation.definition.tag.end.xml
+      push: expect-boolean
 
   fold-scope-value:
     - match: '((<)(string)\s*(>))'

--- a/Package/TextMate Preferences/syntax_test_tmPreferences.xml
+++ b/Package/TextMate Preferences/syntax_test_tmPreferences.xml
@@ -118,6 +118,89 @@
                 </dict>
             </array>
 
+            <key>indentationFoldingEnabled</key>
+<!--             ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences -->
+            <false/>
+<!--         ^^^^^ entity.name.tag.localname.xml constant.language.boolean.plist -->
+
+            <key>scopeFoldingEnabled</key>
+<!--             ^^^^^^^^^^^^^^^^^^^ meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences -->
+            <false/>
+<!--         ^^^^^ entity.name.tag.localname.xml constant.language.boolean.plist -->
+
+            <key>foldScopes</key>
+<!--             ^^^^^^^^^^ meta.inside-dict-key.plist keyword.other.foldScopes.tmPreferences -->
+            <array>
+                <dict>
+                        <key>begin<
+<!--                    ^^^^^^^^^^^^ meta.inside-dict.foldScopes.tmPreferences -->
+<!--                     ^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+<!--                         ^^^^^ invalid.illegal.unexpected-text.plist -->
+<!--                              ^ punctuation.definition.tag.begin.xml -->
+                </dict>
+<!--            ^^^^^^^ meta.inside-array.plist meta.tag.xml - invalid -->
+            </array>
+<!--        ^^^^^^^^ meta.inside-dict.settings.tmPreferences meta.tag.xml - invalid -->
+
+            <key>foldScopes</key>
+            <array>
+                <dict>
+                        <key>begin</key>
+<!--                    ^^^^^^^^^^^^^^^^ meta.inside-dict.foldScopes.tmPreferences -->
+<!--                    ^^^^^ meta.tag.xml - meta.inside-dict-key -->
+<!--                     ^^^ entity.name.tag.localname.xml -->
+<!--                         ^^^^^ meta.inside-dict-key.plist -->
+<!--                              ^^^^^^ meta.tag.xml - meta.inside-dict-key -->
+<!--                                ^^^ entity.name.tag.localname.xml -->
+                </dict>
+<!--            ^^^^^^^ meta.inside-array.plist meta.tag.xml - invalid -->
+            </array>
+<!--        ^^^^^^^^ meta.inside-dict.settings.tmPreferences meta.tag.xml - invalid -->
+
+            <key>foldScopes</key>
+            <array>
+                <dict>
+                        <key>begin</key>
+<!--                    ^^^^^^^^^^^^^^^^ meta.inside-dict.foldScopes.tmPreferences -->
+<!--                    ^^^^^ meta.tag.xml - meta.inside-dict-key -->
+<!--                     ^^^ entity.name.tag.localname.xml -->
+<!--                         ^^^^^ meta.inside-dict-key.plist -->
+<!--                              ^^^^^^ meta.tag.xml - meta.inside-dict-key -->
+<!--                                ^^^ entity.name.tag.localname.xml -->
+                        <string>
+<!--                    ^^^^^^^^ meta.scope-name.tmPreferences meta.tag.xml -->
+                </dict>
+<!--           ^ invalid.illegal.missing-tag-end.xml -->
+<!--            ^^^^^^^ meta.inside-array.plist meta.tag.xml - invalid -->
+            </array>
+<!--        ^^^^^^^^ meta.inside-dict.settings.tmPreferences meta.tag.xml - invalid -->
+
+            <key>foldScopes</key>
+            <array>
+                <dict>
+                        <key>begin</key>
+<!--                    ^^^^^^^^^^^^^^^^ meta.inside-dict.foldScopes.tmPreferences -->
+<!--                    ^^^^^ meta.tag.xml - meta.inside-dict-key -->
+<!--                     ^^^ entity.name.tag.localname.xml -->
+<!--                         ^^^^^ meta.inside-dict-key.plist -->
+<!--                              ^^^^^^ meta.tag.xml - meta.inside-dict-key -->
+<!--                                ^^^ entity.name.tag.localname.xml -->
+                        <string>punctuation.section.group.begin</string>
+<!--                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-dict.foldScopes.tmPreferences meta.scope-name.tmPreferences -->
+<!--                    ^^^^^^^^ meta.tag.xml -->
+<!--                            ^^^^^^^^^^^ string.unquoted.scope-segment.scope-selector -->
+<!--                                       ^ punctuation.separator.scope-segments.scope-selector -->
+<!--                                        ^^^^^^^ string.unquoted.scope-segment.scope-selector -->
+<!--                                               ^ punctuation.separator.scope-segments.scope-selector -->
+<!--                                                ^^^^^ string.unquoted.scope-segment.scope-selector -->
+<!--                                                     ^ punctuation.separator.scope-segments.scope-selector -->
+<!--                                                      ^^^^^ string.unquoted.scope-segment.scope-selector -->
+<!--                                                           ^^^^^^^^^ meta.tag.xml -->
+                </dict>
+<!--            ^^^^^^^ meta.inside-array.plist meta.tag.xml - invalid -->
+            </array>
+<!--        ^^^^^^^^ meta.inside-dict.settings.tmPreferences meta.tag.xml - invalid -->
+
             <key>preserveIndent</key>
 <!--             ^^^^^^^^^^^^^^ meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences -->
             <false />


### PR DESCRIPTION
This PR adds support for the following tmPreferences keys

- indentationFoldingEnabled
- scopeFoldingEnabled
- foldScopes

Some effort has been made to avoid highlighting the whole file invalid in various incomplete code scenarios.