### PR TITLE
TextMate Preferences: Refactor Syntax

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -38,7 +38,6 @@ jobs:
           - build: 4107
             packages: v4107
             continue_on_error: true
-    continue-on-error: ${{ matrix.continue_on_error }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -46,3 +45,7 @@ jobs:
         with:
           build: ${{ matrix.build }}
           default_packages: ${{ matrix.packages }}
+        # On the step level, this does not cause the entire job to fail
+        # and thus mark PRs as failing when only one of our tests failed.
+        # See also https://github.com/github/feedback/discussions/15452.
+        continue-on-error: ${{ matrix.continue_on_error }}

--- a/Package/Property List/Completions/Tags.sublime-completions
+++ b/Package/Property List/Completions/Tags.sublime-completions
@@ -1,5 +1,5 @@
 {
-    "scope": "meta.inside-plist.plist - (comment | meta.tag | meta.inside-value | meta.inside-dict-key)",
+    "scope": "text.xml.plist meta.inside-plist - meta.tag - meta.inside-value - meta.inside-dict-key - comment - string",
     "completions": [
         {
             "trigger": "array",

--- a/Package/Property List/Property List.sublime-syntax
+++ b/Package/Property List/Property List.sublime-syntax
@@ -72,13 +72,11 @@ contexts:
     - include: any-elements
 
   plist-end:
-    - match: (</)(plist)\s*(>)
-      scope: meta.tag.xml
+    - match: (</)(plist){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      set: whitespace-or-tags
+      set: [whitespace-or-tags, inside-tag]
 
   any-elements:
     - include: comments
@@ -108,6 +106,9 @@ contexts:
     - match: '>'
       scope: punctuation.definition.tag.end.xml
       set: inside-array
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
+      set: inside-array
     - include: tag-end-self-closing
 
   inside-array:
@@ -116,13 +117,11 @@ contexts:
     - include: any-elements
 
   array-end:
-    - match: (</)(array)\s*(>)
-      scope: meta.tag.xml
+    - match: (</)(array){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      pop: 1
+      set: inside-tag
 
   dict:
     - match: (<)(dict){{tag_name_break}}
@@ -136,6 +135,9 @@ contexts:
     - match: '>'
       scope: punctuation.definition.tag.end.xml
       set: inside-dict
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
+      set: inside-dict
     - include: tag-end-self-closing
 
   inside-dict:
@@ -145,13 +147,11 @@ contexts:
     - include: whitespace-or-tags
 
   dict-end:
-    - match: (</)(dict)\s*(>)
-      scope: meta.tag.xml
+    - match: (</)(dict){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      pop: 1
+      set: inside-tag
 
   dict-keys:
     - match: (<)(key){{tag_name_break}}
@@ -167,7 +167,9 @@ contexts:
         1: invalid.illegal.self-closing.xml
         2: punctuation.definition.tag.end.xml
       set: [any-element, inside-dict-key]
-    - include: tag-end-missing-pop
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
+      set: [any-element, inside-dict-key]
 
   inside-dict-key:
     - meta_content_scope: meta.inside-dict-key.plist
@@ -175,13 +177,11 @@ contexts:
     - include: value-content
 
   key-end:
-    - match: (</)(key)\s*(>)
-      scope: meta.tag.xml
+    - match: (</)(key){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      pop: 1
+      set: inside-tag
 
   boolean:
     - match: (<)(true|false){{tag_name_break}}
@@ -193,6 +193,7 @@ contexts:
   inside-boolean:
     - meta_scope: meta.tag.xml
     - include: tag-end-self-closing
+    - include: tag-end
 
   data:
     - match: (<)(data){{tag_name_break}}
@@ -206,6 +207,9 @@ contexts:
     - match: '>'
       scope: punctuation.definition.tag.end.xml
       set: inside-data
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
+      set: inside-data
     - include: tag-end-self-closing
 
   inside-data:
@@ -214,13 +218,11 @@ contexts:
     - include: value-content # TODO: expect base-64 only
 
   data-end:
-    - match: (</)(data)\s*(>)
-      scope: meta.tag.xml
+    - match: (</)(data){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      pop: 1
+      set: inside-tag
 
   date:
     - match: (<)(date){{tag_name_break}}
@@ -244,13 +246,11 @@ contexts:
     - include: value-content # TODO: ISO 8601 format date i.e. "2007-04-05T14:30Z" or "2007-04-05T12:30-02:00"
 
   date-end:
-    - match: (</)(date)\s*(>)
-      scope: meta.tag.xml
+    - match: (</)(date){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      pop: 1
+      set: inside-tag
 
   number:
     - include: integer
@@ -276,13 +276,11 @@ contexts:
 
   inside-integer:
     - meta_content_scope: meta.inside-value.integer.plist
-    - match: (</)(integer)\s*(>)
-      scope: meta.tag.xml
+    - match: (</)(integer){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      pop: 1
+      set: inside-tag
     - match: '[-+]?\d+'
       scope: constant.numeric.plist
       push: after-number
@@ -309,13 +307,11 @@ contexts:
 
   inside-real:
     - meta_content_scope: meta.inside-value.real.plist
-    - match: (</)(real)\s*(>)
-      scope: meta.tag.xml
+    - match: (</)(real){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      pop: 1
+      set: inside-tag
     - match: '[-+]?\d+(\.\d*)?(E[-+]\d+)?'
       scope: constant.numeric.plist
       push: after-number
@@ -338,6 +334,9 @@ contexts:
     - match: '>'
       scope: punctuation.definition.tag.end.xml
       set: inside-string
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
+      set: inside-string
     - include: tag-end-self-closing
 
   inside-string:
@@ -346,13 +345,11 @@ contexts:
     - include: value-content
 
   string-end:
-    - match: (</)(string)\s*(>)
-      scope: meta.tag.xml
+    - match: (</)(string){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      pop: 1
+      set: inside-tag
 
   value-content:
     - include: cdata
@@ -387,18 +384,18 @@ contexts:
   inside-tag:
     - meta_scope: meta.tag.xml
     - include: tag-end
+    - include: tag-end-self-closing
+    - include: tag-end-missing-pop
 
   tag-end:
     - match: '>'
       scope: punctuation.definition.tag.end.xml
       pop: 1
-    - include: tag-end-missing-pop
 
   tag-end-self-closing:
     - match: />
       scope: punctuation.definition.tag.end.xml
       pop: 1
-    - include: tag-end-missing-pop
 
   tag-end-missing-pop:
     # pop, if the next opening tag is following, while scoping the

--- a/Package/Property List/Property List.sublime-syntax
+++ b/Package/Property List/Property List.sublime-syntax
@@ -378,13 +378,14 @@ contexts:
       scope: invalid.illegal.unexpected-text.plist
 
   unknown-tags:
-    - match: <
-      scope: punctuation.definition.tag.begin.xml
-      push: inside-unknown-tag
+    - match: (</?)([^\s<>]*)
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: invalid.illegal.unknown-or-unexpected-tag.plist
+      push: inside-tag
 
-  inside-unknown-tag:
+  inside-tag:
     - meta_scope: meta.tag.xml
-    - meta_content_scope: invalid.illegal.unknown-or-unexpected-tag.plist
     - include: tag-end
 
   tag-end:

--- a/Package/Property List/Property List.sublime-syntax
+++ b/Package/Property List/Property List.sublime-syntax
@@ -368,6 +368,7 @@ contexts:
   whitespace-or-tags:
     - include: comments
     - include: unknown-tags
+    - include: should-be-entity
     - include: illegal-text
 
   illegal-text:
@@ -375,7 +376,7 @@ contexts:
       scope: invalid.illegal.unexpected-text.plist
 
   unknown-tags:
-    - match: (</?)([^\s<>]*)
+    - match: (</?)([[:alpha:]][^\s<>]*)
       captures:
         1: punctuation.definition.tag.begin.xml
         2: invalid.illegal.unknown-or-unexpected-tag.plist

--- a/Package/Property List/Property List.sublime-syntax
+++ b/Package/Property List/Property List.sublime-syntax
@@ -14,6 +14,8 @@
 ---
 name: Property List (XML)
 scope: text.xml.plist
+version: 2
+
 file_extensions:
   - plist
   - tmSnippet
@@ -24,13 +26,33 @@ file_extensions:
   - hidden-tmTheme
   - hidden-stTheme
   - hidden-tmLanguage
+
 # first_line_match: ^\s*<!DOCTYPE plist|^\s*<plist version="1\.0">
+
+variables:
+  tag_name_break: (?![[:alnum:]:_.-])
 
 contexts:
 
   main:
-    - include: xml-declarations
-    - match: '(<)(plist)(?:\s+(version)\s*(=)\s*((")1.0(")))?\s*(>)'
+    - include: plist
+
+  comments:
+    - include: scope:text.xml#comment
+
+  cdata:
+    - include: scope:text.xml#cdata
+
+  entity:
+    - include: scope:text.xml#entity
+
+  should-be-entity:
+    - include: scope:text.xml#should-be-entity
+
+  plist:
+    - include: scope:text.xml#preprocessor
+    - include: scope:text.xml#doctype
+    - match: (<)(plist)(?:\s+(version)\s*(=)\s*((")1\.0(")))?\s*(>)
       scope: meta.tag.xml
       captures:
         1: punctuation.definition.tag.begin
@@ -41,214 +63,341 @@ contexts:
         6: punctuation.definition.string.begin.xml
         7: punctuation.definition.string.end.xml
         8: punctuation.definition.tag.end
-      push:
-        - meta_content_scope: meta.inside-plist.plist
-        - match: '(</)(plist)\s*(>)'
-          scope: meta.tag.xml
-          captures:
-            1: punctuation.definition.tag.begin.xml
-            2: entity.name.tag.localname.xml
-            3: punctuation.definition.tag.end.xml
-          set: whitespace-or-tag
-        - include: comments
-        - match: '(?=\S)'
-          push: any-known-element
-    - include: whitespace-or-tag
+      set: inside-plist
+    - include: whitespace-or-tags
 
-  xml-declarations:
-    - match: '^(?=<\?|<!)'
-      push:
-        - match: $
-          pop: true
-        - include: scope:text.xml
+  inside-plist:
+    - meta_content_scope: meta.inside-plist.plist
+    - include: plist-end
+    - include: any-elements
 
-  comments:
-    # this is simplified; actual xml comments are more complicated
-    - match: '<!--'
-      scope: punctuation.definition.comment.begin.xml
-      push:
-        - meta_scope: comment.block.xml
-        - match: '-->'
-          scope: punctuation.definition.comment.end.xml
-          pop: true
+  plist-end:
+    - match: (</)(plist)\s*(>)
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set: whitespace-or-tags
 
-  unknown-tag:
+  any-elements:
+    - include: comments
+    - match: (?=\S)
+      push: any-element
+
+  any-element:
+    # this context pops after the first matched element
+    - include: boolean
+    - include: data
+    - include: date
+    - include: number
+    - include: string
+    - include: array
+    - include: dict
+    - include: whitespace-or-tags
+
+  array:
+    - match: (<)(array){{tag_name_break}}
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+      set: inside-array-tag
+
+  inside-array-tag:
     - meta_scope: meta.tag.xml
-    - meta_content_scope: invalid.illegal.unknown-or-unexpected-tag.plist
     - match: '>'
       scope: punctuation.definition.tag.end.xml
-      pop: true
-    - include: tag-end-missing-pop
+      set: inside-array
+    - include: tag-end-self-closing
 
-  number:
-    - match: '(<)(integer)\s*(>)'
+  inside-array:
+    - meta_content_scope: meta.inside-array.plist
+    - include: array-end
+    - include: any-elements
+
+  array-end:
+    - match: (</)(array)\s*(>)
       scope: meta.tag.xml
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
         3: punctuation.definition.tag.end.xml
-      set:
-        - meta_content_scope: meta.inside-value.integer.plist
-        - match: '[+-]?\d+'
-          scope: constant.numeric.plist
-          push:
-            - match: '[^\s<]+'
-              scope: invalid.illegal.unexpected-text.plist
-            - match: '(?=<)'
-              pop: true
-        - match: '[^\s<]+'
-          scope: invalid.illegal.expected-integer.plist
-        - include: pop-tag-no-children
-    - match: '(<)(real)\s*(>)'
-      scope: meta.tag.xml
+      pop: 1
+
+  dict:
+    - match: (<)(dict){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      set:
-        - meta_content_scope: meta.inside-value.real.plist
-        - match: '[+-]?\d+(\.\d*)?(E[+-]\d+)?'
-          scope: constant.numeric.plist
-          push:
-            - match: '[^\s<]+'
-              scope: invalid.illegal.unexpected-text.plist
-            - match: '(?=<)'
-              pop: true
-        - match: '[^\s<]+'
-          scope: invalid.illegal.expected-number.plist
-        - include: pop-tag-no-children
+      set: inside-dict-tag
 
-  boolean:
-    - match: '(<)(true|false)\s*(/>)'
-      scope: meta.tag.xml
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.localname.xml constant.language.boolean.plist
-        3: punctuation.definition.tag.end.xml
-      pop: true
+  inside-dict-tag:
+    - meta_scope: meta.tag.xml
+    - match: '>'
+      scope: punctuation.definition.tag.end.xml
+      set: inside-dict
+    - include: tag-end-self-closing
 
-  string:
-    - match: '(<)(string)\s*(>)'
-      scope: meta.tag.xml
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      set:
-        - meta_content_scope: meta.inside-value.string.plist
-        - include: pop-tag-no-children
-
-  date:
-    - match: '(<)(date)\s*(>)'
-      scope: meta.tag.xml
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      set:
-        - meta_content_scope: meta.inside-value.date.plist
-        - include: pop-tag-no-children # TODO: ISO 8601 format date i.e. "2007-04-05T14:30Z" or "2007-04-05T12:30-02:00"
-
-  data:
-    - match: '(<)(data)\s*(>)'
-      scope: meta.tag.xml
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      set:
-        - meta_content_scope: meta.inside-value.data.plist
-        - include: pop-tag-no-children # TODO: expect base-64 only
-
-  empty-array:
-    - match: '(<)(array)\s*(/>)'
-      scope: meta.tag.xml
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      pop: true
-
-  any-known-element:
-    # this context pops after the first matched element
-    - include: number
-    - include: boolean
-    - include: string
-    - include: date
-    - include: data
-    - include: empty-array
-    - match: '(<)(dict)\s*(>)'
-      scope: meta.tag.xml
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      set: dict-key
-    - match: '(<)(array)\s*(>)'
-      scope: meta.tag.xml
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      set: end-of-array
-    - include: whitespace-or-tag
-
-  pop-tag-no-children:
-    - match: '(</)(\2)\s*(>)'
-      scope: meta.tag.xml
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      pop: true
-    - match: '<(?!!)'
-      scope: punctuation.definition.tag.begin.xml
-      push: unknown-tag
-    - include: scope:text.xml
-
-  dict-key:
+  inside-dict:
     - meta_content_scope: meta.inside-dict.plist
-    - match: '(</)(dict)\s*(>)'
+    - include: dict-end
+    - include: dict-keys
+    - include: whitespace-or-tags
+
+  dict-end:
+    - match: (</)(dict)\s*(>)
       scope: meta.tag.xml
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
         3: punctuation.definition.tag.end.xml
-      pop: true
-    - match: '(<)(key)\s*(>)'
-      scope: meta.tag.xml
+      pop: 1
+
+  dict-keys:
+    - match: (<)(key){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      push: [any-known-element, inside-dict-key]
-    - include: whitespace-or-tag
+      push: inside-key-tag
+
+  inside-key-tag:
+    - meta_scope: meta.tag.xml
+    - match: (/?)(>)
+      captures:
+        1: invalid.illegal.self-closing.xml
+        2: punctuation.definition.tag.end.xml
+      set: [any-element, inside-dict-key]
+    - include: tag-end-missing-pop
 
   inside-dict-key:
     - meta_content_scope: meta.inside-dict-key.plist
-    - include: pop-tag-no-children
+    - include: key-end
+    - include: value-content
 
-  whitespace-or-tag:
-    - include: comments
-    - match: '<'
-      scope: punctuation.definition.tag.begin.xml
-      push: unknown-tag
-    - match: '\s+'
-    - match: '[^\s<]+'
-      scope: invalid.illegal.unexpected-text.plist
-
-  end-of-array:
-    - meta_content_scope: meta.inside-array.plist
-    - include: comments
-    - match: '(</)(array)\s*(>)'
+  key-end:
+    - match: (</)(key)\s*(>)
       scope: meta.tag.xml
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
         3: punctuation.definition.tag.end.xml
-      pop: true
-    - match: '(?=\S)'
-      push: any-known-element
+      pop: 1
+
+  boolean:
+    - match: (<)(true|false){{tag_name_break}}
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml constant.language.boolean.plist
+      set: inside-boolean
+
+  inside-boolean:
+    - meta_scope: meta.tag.xml
+    - include: tag-end-self-closing
+
+  data:
+    - match: (<)(data){{tag_name_break}}
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+      set: inside-data-tag
+
+  inside-data-tag:
+    - meta_scope: meta.tag.xml
+    - match: '>'
+      scope: punctuation.definition.tag.end.xml
+      set: inside-data
+    - include: tag-end-self-closing
+
+  inside-data:
+    - meta_content_scope: meta.inside-value.data.plist
+    - include: data-end
+    - include: value-content # TODO: expect base-64 only
+
+  data-end:
+    - match: (</)(data)\s*(>)
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      pop: 1
+
+  date:
+    - match: (<)(date){{tag_name_break}}
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+      set: inside-date-tag
+
+  inside-date-tag:
+    - meta_scope: meta.tag.xml
+    - match: (/?)(>)
+      captures:
+        1: invalid.illegal.self-closing.xml
+        2: punctuation.definition.tag.end.xml
+      set: inside-date
+    - include: tag-end-missing-pop
+
+  inside-date:
+    - meta_content_scope: meta.inside-value.date.plist
+    - include: date-end
+    - include: value-content # TODO: ISO 8601 format date i.e. "2007-04-05T14:30Z" or "2007-04-05T12:30-02:00"
+
+  date-end:
+    - match: (</)(date)\s*(>)
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      pop: 1
+
+  number:
+    - include: integer
+    - include: real
+
+  integer:
+    - match: (<)(integer){{tag_name_break}}
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set: inside-integer-tag
+
+  inside-integer-tag:
+    - meta_scope: meta.tag.xml
+    - match: (/?)(>)
+      captures:
+        1: invalid.illegal.self-closing.xml
+        2: punctuation.definition.tag.end.xml
+      set: inside-integer
+    - include: tag-end-missing-pop
+
+  inside-integer:
+    - meta_content_scope: meta.inside-value.integer.plist
+    - match: (</)(integer)\s*(>)
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      pop: 1
+    - match: '[-+]?\d+'
+      scope: constant.numeric.plist
+      push: after-number
+    - match: '[^\s<]+'
+      scope: invalid.illegal.expected-number.plist
+
+  real:
+    - match: (<)(real){{tag_name_break}}
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      set: inside-real-tag
+
+  inside-real-tag:
+    - meta_scope: meta.tag.xml
+    - match: (/?)(>)
+      captures:
+        1: invalid.illegal.self-closing.xml
+        2: punctuation.definition.tag.end.xml
+      set: inside-real
+    - include: tag-end-missing-pop
+
+  inside-real:
+    - meta_content_scope: meta.inside-value.real.plist
+    - match: (</)(real)\s*(>)
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      pop: 1
+    - match: '[-+]?\d+(\.\d*)?(E[-+]\d+)?'
+      scope: constant.numeric.plist
+      push: after-number
+    - include: illegal-text
+
+  after-number:
+    - match: (?=<)
+      pop: 1
+    - include: illegal-text
+
+  string:
+    - match: (<)(string){{tag_name_break}}
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+      set: inside-string-tag
+
+  inside-string-tag:
+    - meta_scope: meta.tag.xml
+    - match: '>'
+      scope: punctuation.definition.tag.end.xml
+      set: inside-string
+    - include: tag-end-self-closing
+
+  inside-string:
+    - meta_content_scope: meta.inside-value.string.plist
+    - include: string-end
+    - include: value-content
+
+  string-end:
+    - match: (</)(string)\s*(>)
+      scope: meta.tag.xml
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+        3: punctuation.definition.tag.end.xml
+      pop: 1
+
+  value-content:
+    - include: cdata
+    - include: comments
+    - include: unknown-tags
+    - include: entity
+    - include: should-be-entity
+    - include: value-bailout
+
+  value-bailout:
+    # don't escalate errors caused by incomplete tags beyound array or dict boundaries
+    - match: \s?(?=</(?:array|dict){{tag_name_break}})
+      scope: invalid.illegal.missing-tag.plist
+      pop: 1
+
+  whitespace-or-tags:
+    - include: comments
+    - include: unknown-tags
+    - include: illegal-text
+
+  illegal-text:
+    - match: '[^\s<]+'
+      scope: invalid.illegal.unexpected-text.plist
+
+  unknown-tags:
+    - match: <
+      scope: punctuation.definition.tag.begin.xml
+      push: inside-unknown-tag
+
+  inside-unknown-tag:
+    - meta_scope: meta.tag.xml
+    - meta_content_scope: invalid.illegal.unknown-or-unexpected-tag.plist
+    - include: tag-end
+
+  tag-end:
+    - match: '>'
+      scope: punctuation.definition.tag.end.xml
+      pop: 1
+    - include: tag-end-missing-pop
+
+  tag-end-self-closing:
+    - match: />
+      scope: punctuation.definition.tag.end.xml
+      pop: 1
+    - include: tag-end-missing-pop
 
   tag-end-missing-pop:
     # pop, if the next opening tag is following, while scoping the

--- a/Package/Property List/Snippets/plist (in-tag).sublime-snippet
+++ b/Package/Property List/Snippets/plist (in-tag).sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
-	<content><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
+	<content><![CDATA[?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 $0
 </plist>
 ]]></content>
 	<tabTrigger>plist</tabTrigger>
-	<scope>text.xml.plist - text.xml.plist.textmate.preferences - text.xml meta - comment - string - invalid.illegal.missing-entity</scope>
+	<scope>text.xml.plist invalid.illegal.missing-entity - text.xml.plist.textmate.preferences</scope>
 </snippet>

--- a/Package/Property List/Snippets/plist.sublime-snippet
+++ b/Package/Property List/Snippets/plist.sublime-snippet
@@ -1,9 +1,10 @@
 <snippet>
 	<content><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 $0
 </plist>
 ]]></content>
 	<tabTrigger>plist</tabTrigger>
-	<scope>text.xml.plist - text.xml.plist.textmate.preferences - meta.inside-plist - meta.tag</scope>
+	<scope>text.xml.plist - text.xml.plist.textmate.preferences - text.xml meta - comment - string</scope>
 </snippet>

--- a/Package/Property List/syntax_test_plist.xml
+++ b/Package/Property List/syntax_test_plist.xml
@@ -45,7 +45,7 @@
 <!--                          ^^^^^ meta.inside-value.string.plist constant.character.entity.named.xml -->
 <!--                                ^ invalid.illegal.bad-ampersand.xml -->
 <!--                                         ^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
-<!--                                              ^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+<!--                                               ^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
 <!--                                                     ^ - invalid.illegal.unknown-or-unexpected-tag.plist -->
         <key>abc</key><string><![CDATA[&amp; & hello <key></key></string>]]>test&amp;<![CDATA[cool]]></string>
 <!--                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist -->
@@ -60,13 +60,13 @@
 <!--                                                                                              ^^^ punctuation.definition.tag.end.xml -->
 <!--                                                                                                 ^^^^^^^^^ meta.tag.xml - invalid -->
         <string>test</string>
-<!--    ^ punctuation.definition.tag.begin.xml -->
-<!--     ^^^^^^  invalid.illegal.unknown-or-unexpected-tag.plist -->
-<!--           ^ punctuation.definition.tag.end.xml -->
+<!--    ^ punctuation.definition.tag.begin.xml - invalid -->
+<!--     ^^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+<!--           ^ punctuation.definition.tag.end.xml - invalid -->
 <!--            ^^^^ invalid.illegal.unexpected-text.plist -->
-<!--                ^ punctuation.definition.tag.begin.xml -->
-<!--                 ^^^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
-<!--                        ^ punctuation.definition.tag.end.xml -->
+<!--                ^^ punctuation.definition.tag.begin.xml - invalid -->
+<!--                  ^^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+<!--                        ^ punctuation.definition.tag.end.xml - invalid -->
         <key></key><integer>
 <!--                ^^^^^^^ meta.tag.xml entity.name.tag.localname.xml - invalid -->
             +123 456
@@ -74,8 +74,10 @@
 <!--             ^^^ meta.inside-value.integer.plist invalid.illegal.unexpected-text.plist -->
         </integer>
 <!--      ^^^^^^^ meta.tag - invalid -->
-        <key>array</array>
-<!--               ^^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+        <key>array</array  >
+<!--              ^^ - invalid -->
+<!--                ^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+<!--                     ^^ - invalid -->
         </key><array />
 <!--    ^^^^^^^^^^^^^^^ meta.tag.xml -->
 <!--           ^^^^^ entity.name.tag.localname.xml - invalid -->

--- a/Package/Property List/syntax_test_plist.xml
+++ b/Package/Property List/syntax_test_plist.xml
@@ -1,5 +1,14 @@
 <!-- SYNTAX TEST "Packages/PackageDev/Package/Property List/Property List.sublime-syntax" -->
 <!-- <- comment.block.xml punctuation.definition.comment.begin.xml -->
+     <!DOCTYPE plist PUBLIC "plist" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.sgml.doctype.xml -->
+<!-- ^^ punctuation.definition.tag.begin.xml -->
+<!--   ^^^^^^^ keyword.declaration.doctype.xml -->
+<!--           ^^^^^ variable.other.documentroot.localname.xml -->
+<!--                 ^^^^^^ storage.type.external-content.xml -->
+<!--                        ^^^^^^^ meta.string.xml string.quoted.double.xml -->
+<!--                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.xml string.quoted.double.xml -->
+<!--                                                                                ^ punctuation.definition.tag.end.xml -->
      <plist version="1.0">
 <!-- ^^^^^^^^^^^^^^^^^^^^^ meta.tag.xml -->
 <!--  ^^^^^ entity.name.tag.localname.xml -->
@@ -99,9 +108,13 @@ ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4=</data>
     </dict>
 <!--  ^^^^ meta.inside-plist.plist meta.tag.xml entity.name.tag.localname.xml - invalid -->
 </plist>
-<!-- ^^ meta.inside-plist.plist meta.tag.xml entity.name.tag.localname.xml - invalid -->
+<!-- ^^ meta.tag.xml entity.name.tag.localname.xml - invalid -->
 test
 <!-- <- invalid.illegal.unexpected-text.plist -->
 <!--^ - invalid -->
 <!-- comment -->
 <!-- <- comment.block.xml punctuation.definition.comment.begin.xml -->
+<plist>
+<!-- <- meta.tag.xml punctuation.definition.tag.begin.xml -->
+<!-- ^^ meta.tag.xml -->
+<!-- ^ invalid.illegal.unknown-or-unexpected-tag.plist -->

--- a/Package/Property List/syntax_test_plist.xml
+++ b/Package/Property List/syntax_test_plist.xml
@@ -1,14 +1,14 @@
 <!-- SYNTAX TEST "Packages/PackageDev/Package/Property List/Property List.sublime-syntax" -->
 <!-- <- comment.block.xml punctuation.definition.comment.begin.xml -->
-     <!DOCTYPE plist PUBLIC "plist" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.sgml.doctype.xml -->
+     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.sgml.doctype.xml -->
 <!-- ^^ punctuation.definition.tag.begin.xml -->
 <!--   ^^^^^^^ keyword.declaration.doctype.xml -->
 <!--           ^^^^^ variable.other.documentroot.localname.xml -->
 <!--                 ^^^^^^ storage.type.external-content.xml -->
-<!--                        ^^^^^^^ meta.string.xml string.quoted.double.xml -->
-<!--                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.xml string.quoted.double.xml -->
-<!--                                                                                ^ punctuation.definition.tag.end.xml -->
+<!--                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.xml string.quoted.double.xml -->
+<!--                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.xml string.quoted.double.xml -->
+<!--                                                                                                      ^ punctuation.definition.tag.end.xml -->
      <plist version="1.0">
 <!-- ^^^^^^^^^^^^^^^^^^^^^ meta.tag.xml -->
 <!--  ^^^^^ entity.name.tag.localname.xml -->

--- a/Package/Property List/syntax_test_plist.xml
+++ b/Package/Property List/syntax_test_plist.xml
@@ -109,6 +109,23 @@ ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4=</data>
         </array>
     </dict>
 <!--  ^^^^ meta.inside-plist.plist meta.tag.xml entity.name.tag.localname.xml - invalid -->
+
+    <dict
+       <key name </key
+<!--  ^ meta.tag.xml invalid.illegal.missing-tag-end.xml -->
+<!--   ^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml -->
+       <string>value</string>
+
+       <key name </key
+       <string value </string
+<!--  ^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml invalid.illegal.missing-tag-end.xml -->
+<!--   ^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml -->
+
+       <key name </key
+       <string value </string
+    </dict
+   <!-- <- meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml invalid.illegal.missing-tag-end.xml -->
+
 </plist>
 <!-- ^^ meta.tag.xml entity.name.tag.localname.xml - invalid -->
 test

--- a/Package/Scope Selector (XML).sublime-syntax
+++ b/Package/Scope Selector (XML).sublime-syntax
@@ -1,0 +1,31 @@
+%YAML 1.2
+---
+scope: source.scope-selector.xml
+hidden: true
+
+extends: Scope Selector.sublime-syntax
+
+contexts:
+
+  base:
+    - meta_append: true
+    - include: scope:text.xml#entity
+    - include: scope:text.xml#should-be-entity
+
+  inside-group:
+    - meta_prepend: true
+    # XML comments or end tags terminate scope selectors.
+    # Thus pop all contexts off stack.
+    - match: \s?(?=</|<!--)
+      scope: invalid.illegal.missing-group-end.scope-selector
+      pop: 1
+
+  operators:
+    - meta_prepend: true
+    - match: (&)amp(;)
+      scope: constant.character.entity.xml keyword.operator.with.scope-selector
+      captures:
+        1: punctuation.definition.constant.xml
+        2: punctuation.definition.constant.xml
+    - match: '&'
+      scope: invalid.illegal.bad-ampersand.xml

--- a/Package/Scope Selector.sublime-syntax
+++ b/Package/Scope Selector.sublime-syntax
@@ -5,45 +5,55 @@ scope: source.scope-selector
 hidden: true
 
 variables:
-  scope_segment: '\w+(?:[\w-]*\+*)' # \+* is for the non standard scope.c++ scopes
+  scope_segment: \w+(?:[\w-]*\+*) # \+* is for the non standard scope.c++ scopes
 
 contexts:
   main:
-    - match: '\)'
-      scope: invalid.illegal.stray-bracket.scope-selector
     - include: base
+    - match: \)
+      scope: invalid.illegal.stray-bracket.scope-selector
 
   base:
-    - match: '(?:^\s*)?({{scope_segment}})'
+    - match: (?:^\s*)?({{scope_segment}})
       captures:
         1: string.unquoted.scope-segment.scope-selector
-      push:
-        - match: '(\.)(\.+)?'
-          captures:
-            1: punctuation.separator.scope-segments.scope-selector
-            2: invalid.illegal.empty-scope-segment.scope-selector
-          pop: true
-        - match: '\s+\('
-          scope: invalid.illegal.operator-required-between-scope-and-group.scope-selector
-        - match: '\s+(?=\w)'
-          scope: keyword.operator.right.scope-selector
-          pop: true
-        - match: ''
-          pop: true
+      push: inside-scope-segment
+    - match: \(
+      scope: punctuation.section.group.begin.scope-selector
+      push: inside-group
+    - include: operators
+
+  inside-group:
+    - meta_scope: meta.group.scope-selector
+    - match: \)
+      scope: punctuation.section.group.end.scope-selector
+      set: after-group
+    - include: base
+
+  after-group:
+    - match: (?:\s*{{scope_segment}}|\.)+
+      scope: invalid.illegal.operator-required-after-group.scope-selector
+    - match: \s*
+      pop: true
+
+  inside-scope-segment:
+    - match: (\.)(\.+)?
+      captures:
+        1: punctuation.separator.scope-segments.scope-selector
+        2: invalid.illegal.empty-scope-segment.scope-selector
+      pop: true
+    - match: \s+\(
+      scope: invalid.illegal.operator-required-between-scope-and-group.scope-selector
+    - match: \s+(?=\w)
+      scope: keyword.operator.right.scope-selector
+      pop: true
+    - match: ''
+      pop: true
+
+  operators:
     - match: '-'
       scope: keyword.operator.without.scope-selector
     - match: '&'
       scope: keyword.operator.with.scope-selector
     - match: '[,|]'
       scope: keyword.operator.or.scope-selector
-    - match: '\('
-      scope: punctuation.section.group.begin.scope-selector
-      push:
-        - match: '\)'
-          scope: punctuation.section.group.end.scope-selector
-          set:
-            - match: '(\s*{{scope_segment}}|\.)+'
-              scope: invalid.illegal.operator-required-after-group.scope-selector
-            - match: '\s*'
-              pop: true
-        - include: base

--- a/Package/TextMate Preferences/Completions/Main Keys (in-key).sublime-completions
+++ b/Package/TextMate Preferences/Completions/Main Keys (in-key).sublime-completions
@@ -1,5 +1,5 @@
 {
-	"scope": "meta.main-key-wrapper.tmPreferences - (meta.tag - punctuation.definition.tag.begin.xml)",
+	"scope": "meta.main.key.tmPreferences - (meta.tag - punctuation.definition.tag.begin.xml)",
 
 	"completions": [
 		{

--- a/Package/TextMate Preferences/Completions/Main Keys.sublime-completions
+++ b/Package/TextMate Preferences/Completions/Main Keys.sublime-completions
@@ -6,25 +6,25 @@
 			"trigger": "name",
 			"contents": "<key>name</key>\n<string>$1</string>",
 			"details": "Name (redundant)",
-			"kind": ["keyword", "k", "main"],
+			"kind": ["snippet", "s", "main"],
 		},
 		{
 			"trigger": "scope",
 			"contents": "<key>scope</key>\n<string>$1</string>",
 			"details": "Scope selector",
-			"kind": ["keyword", "k", "main"],
+			"kind": ["snippet", "s", "main"],
 		},
 		{
 			"trigger": "settings",
 			"contents": "<key>settings</key>\n<dict>\n\t$0\n</dict>",
 			"details": "Settings section",
-			"kind": ["keyword", "k", "main"],
+			"kind": ["snippet", "s", "main"],
 		},
 		{
 			"trigger": "uuid",
 			"contents": "<key>uuid</key>\n<string>$1</string>",
 			"details": "UUID (redundant)",
-			"kind": ["keyword", "k", "main"],
+			"kind": ["snippet", "s", "main"],
 		},
 	]
 }

--- a/Package/TextMate Preferences/Completions/Settings Keys (in-key).sublime-completions
+++ b/Package/TextMate Preferences/Completions/Settings Keys (in-key).sublime-completions
@@ -4,83 +4,83 @@
 	"completions": [
 		{
 			"trigger": "decreaseIndentPattern",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "increaseIndentPattern",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "disableIndentNextLinePattern",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "bracketIndentNextLinePattern",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "unIndentedLinePattern",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "cancelCompletion",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "shellVariables",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "showInSymbolList",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "showInIndexedReferenceList",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "showInIndexedSymbolList",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "symbolTransformation",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "symbolIndexTransformation",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "indentParens",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "indentSquareBrackets",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "preserveIndent",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "indentationFoldingEnabled",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "scopeFoldingEnabled",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "foldScopes",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "excludeTrailingNewline",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 		{
 			"trigger": "icon",
-			"kind": ["snippet", "s", "setting"],
+			"kind": ["keyword", "k", "setting"],
 		},
 	]
 }

--- a/Package/TextMate Preferences/Completions/Settings Keys (in-key).sublime-completions
+++ b/Package/TextMate Preferences/Completions/Settings Keys (in-key).sublime-completions
@@ -1,5 +1,5 @@
 {
-	"scope": "meta.settings-key-wrapper.tmPreferences - (meta.tag - punctuation.definition.tag.begin.xml)",
+	"scope": "meta.settings.key.tmPreferences - (meta.tag - punctuation.definition.tag.begin.xml)",
 
 	"completions": [
 		{

--- a/Package/TextMate Preferences/Completions/foldScopes Keys (in-key).sublime-completions
+++ b/Package/TextMate Preferences/Completions/foldScopes Keys (in-key).sublime-completions
@@ -1,0 +1,21 @@
+{
+	"scope": "meta.foldScopes-key-wrapper.tmPreferences - (meta.tag - punctuation.definition.tag.begin.xml)",
+
+	"completions": [
+		{
+			"trigger": "begin",
+			"kind": ["keyword", "k", "setting"],
+			"details": "Fold region begin scope selector",
+		},
+		{
+			"trigger": "end",
+			"kind": ["keyword", "k", "setting"],
+			"details": "Fold region end scope selector",
+		},
+		{
+			"trigger": "excludeTrailingNewlines",
+			"kind": ["keyword", "k", "setting"],
+			"details": "Exclude trailing newlines from fold region",
+		},
+	]
+}

--- a/Package/TextMate Preferences/Completions/foldScopes Keys (in-key).sublime-completions
+++ b/Package/TextMate Preferences/Completions/foldScopes Keys (in-key).sublime-completions
@@ -1,5 +1,5 @@
 {
-	"scope": "meta.foldScopes-key-wrapper.tmPreferences - (meta.tag - punctuation.definition.tag.begin.xml)",
+	"scope": "meta.foldScopes.key.tmPreferences - (meta.tag - punctuation.definition.tag.begin.xml)",
 
 	"completions": [
 		{

--- a/Package/TextMate Preferences/Completions/foldScopes Keys.sublime-completions
+++ b/Package/TextMate Preferences/Completions/foldScopes Keys.sublime-completions
@@ -1,0 +1,24 @@
+{
+	"scope": "meta.inside-dict.foldScopes.tmPreferences - meta.inside-dict-key - meta.inside-value - meta.tag - comment",
+
+	"completions": [
+		{
+			"trigger": "begin",
+			"contents": "<key>begin</key>\n<string>$1</string>",
+			"kind": ["snippet", "s", "setting"],
+			"details": "Fold region begin scope selector",
+		},
+		{
+			"trigger": "end",
+			"contents": "<key>end</key>\n<string>$1</string>",
+			"kind": ["snippet", "s", "setting"],
+			"details": "Fold region end scope selector",
+		},
+		{
+			"trigger": "excludeTrailingNewlines",
+			"contents": "<key>excludeTrailingNewlines</key>\n<true/>",
+			"kind": ["snippet", "s", "setting"],
+			"details": "Exclude trailing newlines from fold region",
+		},
+	]
+}

--- a/Package/TextMate Preferences/Completions/shellVariable Keys (in-key).sublime-completions
+++ b/Package/TextMate Preferences/Completions/shellVariable Keys (in-key).sublime-completions
@@ -1,0 +1,16 @@
+{
+	"scope": "meta.shellVariable-key-wrapper.tmPreferences - (meta.tag - punctuation.definition.tag.begin.xml)",
+
+	"completions": [
+		{
+			"trigger": "name",
+			"kind": ["keyword", "k", "setting"],
+			"details": "Shell variable's name",
+		},
+		{
+			"trigger": "value",
+			"kind": ["keyword", "k", "setting"],
+			"details": "Shell variable's value",
+		},
+	]
+}

--- a/Package/TextMate Preferences/Completions/shellVariable Keys (in-key).sublime-completions
+++ b/Package/TextMate Preferences/Completions/shellVariable Keys (in-key).sublime-completions
@@ -1,5 +1,5 @@
 {
-	"scope": "meta.shellVariable-key-wrapper.tmPreferences - (meta.tag - punctuation.definition.tag.begin.xml)",
+	"scope": "meta.shellVariable.key.tmPreferences - (meta.tag - punctuation.definition.tag.begin.xml)",
 
 	"completions": [
 		{

--- a/Package/TextMate Preferences/Completions/shellVariable Keys.sublime-completions
+++ b/Package/TextMate Preferences/Completions/shellVariable Keys.sublime-completions
@@ -1,0 +1,18 @@
+{
+	"scope": "meta.inside-dict.shellVariables.tmPreferences - meta.inside-dict-key - meta.inside-value - meta.tag - comment",
+
+	"completions": [
+		{
+			"trigger": "name",
+			"contents": "<key>name</key>\n<string>$1</string>",
+			"kind": ["snippet", "s", "setting"],
+			"details": "Shell variable's name",
+		},
+		{
+			"trigger": "value",
+			"contents": "<key>value</key>\n<string>$1</string>",
+			"kind": ["snippet", "s", "setting"],
+			"details": "Shell variable's value",
+		},
+	]
+}

--- a/Package/TextMate Preferences/Completions/shellVariable Name.sublime-completions
+++ b/Package/TextMate Preferences/Completions/shellVariable Name.sublime-completions
@@ -1,5 +1,5 @@
 {
-    "scope": "meta.shellVariable-name.wrapper.tmPreferences - (meta.tag - punctuation.definition.tag.begin.xml)",
+    "scope": "meta.shellVariable.name.tmPreferences - (meta.tag - punctuation.definition.tag.begin.xml)",
     "completions": [
         {
             "trigger": "TM_COMMENT_DISABLE_INDENT",

--- a/Package/TextMate Preferences/Completions/shellVariable Name.sublime-completions
+++ b/Package/TextMate Preferences/Completions/shellVariable Name.sublime-completions
@@ -3,27 +3,27 @@
     "completions": [
         {
             "trigger": "TM_COMMENT_DISABLE_INDENT",
-            "kind": ["variable", "s", "shellVariable"],
+            "kind": ["variable", "v", "shellVariable"],
         },
         {
             "trigger": "TM_COMMENT_DISABLE_INDENT_2",
-            "kind": ["variable", "s", "shellVariable"],
+            "kind": ["variable", "v", "shellVariable"],
         },
         {
             "trigger": "TM_COMMENT_END",
-            "kind": ["variable", "s", "shellVariable"],
+            "kind": ["variable", "v", "shellVariable"],
         },
         {
             "trigger": "TM_COMMENT_END_2",
-            "kind": ["variable", "s", "shellVariable"],
+            "kind": ["variable", "v", "shellVariable"],
         },
         {
             "trigger": "TM_COMMENT_START",
-            "kind": ["variable", "s", "shellVariable"],
+            "kind": ["variable", "v", "shellVariable"],
         },
         {
             "trigger": "TM_COMMENT_START_2",
-            "kind": ["variable", "s", "shellVariable"],
+            "kind": ["variable", "v", "shellVariable"],
         },
     ]
 }

--- a/Package/TextMate Preferences/Snippets/foldScopes Entry.sublime-snippet
+++ b/Package/TextMate Preferences/Snippets/foldScopes Entry.sublime-snippet
@@ -1,0 +1,12 @@
+<snippet>
+	<content><![CDATA[<dict>
+	<key>begin</key>
+	<string>$1</string>
+	<key>end</key>
+	<string>$2</string>
+	<key>excludeTrailingNewlines</key>
+	<${3:false}/>
+</dict>]]></content>
+	<tabTrigger>fold</tabTrigger>
+	<scope>meta.inside-array.foldScopes.tmPreferences - (meta.inside-dict.foldScopes | comment | meta.tag)</scope>
+</snippet>

--- a/Package/TextMate Preferences/Snippets/plist (in-tag).sublime-snippet
+++ b/Package/TextMate Preferences/Snippets/plist (in-tag).sublime-snippet
@@ -1,0 +1,11 @@
+<snippet>
+	<content><![CDATA[?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	$0
+</dict>
+</plist>
+]]></content>
+	<tabTrigger>plist</tabTrigger>
+	<scope>text.xml.plist.textmate.preferences invalid.illegal.missing-entity</scope>
+</snippet>

--- a/Package/TextMate Preferences/Snippets/plist.sublime-snippet
+++ b/Package/TextMate Preferences/Snippets/plist.sublime-snippet
@@ -7,5 +7,5 @@
 </plist>
 ]]></content>
 	<tabTrigger>plist</tabTrigger>
-	<scope>text.xml.plist.textmate.preferences - meta.inside-plist - meta.tag</scope>
+	<scope>text.xml.plist.textmate.preferences - text.xml meta - comment - string</scope>
 </snippet>

--- a/Package/TextMate Preferences/Snippets/plist.sublime-snippet
+++ b/Package/TextMate Preferences/Snippets/plist.sublime-snippet
@@ -7,5 +7,5 @@
 </plist>
 ]]></content>
 	<tabTrigger>plist</tabTrigger>
-	<scope>text.xml.plist.textmate.preferences - text.xml meta - comment - string</scope>
+	<scope>text.xml.plist.textmate.preferences - text.xml meta - comment - string - invalid.illegal.missing-entity</scope>
 </snippet>

--- a/Package/TextMate Preferences/Snippets/plist.sublime-snippet
+++ b/Package/TextMate Preferences/Snippets/plist.sublime-snippet
@@ -1,9 +1,11 @@
 <snippet>
 	<content><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
-$0
+<dict>
+	$0
+</dict>
 </plist>
 ]]></content>
 	<tabTrigger>plist</tabTrigger>
-	<scope>text.xml.plist - text.xml.plist.textmate.preferences - meta.inside-plist - meta.tag</scope>
+	<scope>text.xml.plist.textmate.preferences - meta.inside-plist - meta.tag</scope>
 </snippet>

--- a/Package/TextMate Preferences/Snippets/shellVariables Entry.sublime-snippet
+++ b/Package/TextMate Preferences/Snippets/shellVariables Entry.sublime-snippet
@@ -1,10 +1,10 @@
 <snippet>
 	<content><![CDATA[<dict>
-    <key>name</key>
-    <string>$1</string>
-    <key>value</key>
-    <string>$2</string>
+	<key>name</key>
+	<string>$1</string>
+	<key>value</key>
+	<string>$2</string>
 </dict>]]></content>
-	<tabTrigger>e</tabTrigger>
-	<scope>meta.inside-dict.settings.tmPreferences meta.inside-array.plist - (meta.inside-array meta.inside-dict | meta.inside-key | meta.inside-value | comment | meta.tag)</scope>
+	<tabTrigger>var</tabTrigger>
+	<scope>meta.inside-array.shellVariables.tmPreferences - (meta.inside-dict.shellVariables | comment | meta.tag)</scope>
 </snippet>

--- a/Package/TextMate Preferences/Symbols - scope.tmPreferences
+++ b/Package/TextMate Preferences/Symbols - scope.tmPreferences
@@ -2,7 +2,7 @@
 <plist version="1.0">
 <dict>
 	<key>scope</key>
-	<string>meta.toc-list.scope.tmPreferences</string>
+	<string>meta.string.selector.tmPreferences - meta.inside-dict.settings</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>

--- a/Package/TextMate Preferences/Symbols - setting.tmPreferences
+++ b/Package/TextMate Preferences/Symbols - setting.tmPreferences
@@ -2,7 +2,7 @@
 <plist version="1.0">
 <dict>
 	<key>scope</key>
-	<string>text.xml.plist.textmate.preferences entity.name.setting</string>
+	<string>text.xml.plist.textmate.preferences entity.name.constant.setting</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>

--- a/Package/TextMate Preferences/Symbols - shellVariable.tmPreferences
+++ b/Package/TextMate Preferences/Symbols - shellVariable.tmPreferences
@@ -2,14 +2,14 @@
 <plist version="1.0">
 <dict>
 	<key>scope</key>
-	<string>entity.name.shellVariable.tmPreferences</string>
+	<string>entity.name.constant.shellVariable.tmPreferences</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>
 		<integer>1</integer>
 		<key>symbolTransformation</key>
 		<string><![CDATA[
-		s/^/   /; # indent ShellVariables
+		s/^/  /; # indent ShellVariables
 		]]></string>
 	</dict>
 </dict>

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-settings
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-settings
@@ -1,4 +1,4 @@
 {
     "extensions": ["tmPreferences"],
-    "auto_complete_selector": "meta.tag - punctuation.definition.tag.begin.xml | meta.settings.key | meta.inside-value.string.shellVariable-name | meta.main.key | meta.shellVariable.name | meta.inside-dict-settings | meta.inside-dict.settings.tmPreferences | meta.inside-dict - meta.inside-value - meta.inside-dict-key",
+    "auto_complete_selector": "text.xml.plist.textmate.preferences - comment - string - meta.inside-value, meta.shellVariable.name, meta.string.selector",
 }

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-settings
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-settings
@@ -1,4 +1,4 @@
 {
     "extensions": ["tmPreferences"],
-    "auto_complete_selector": "meta.tag - punctuation.definition.tag.begin.xml | meta.settings.key | meta.inside-value.string.shellVariable-name | meta.main.key | meta.shellVariable-name.wrapper | meta.inside-dict-settings | meta.inside-dict.settings.tmPreferences | meta.inside-dict - meta.inside-value - meta.inside-dict-key",
+    "auto_complete_selector": "meta.tag - punctuation.definition.tag.begin.xml | meta.settings.key | meta.inside-value.string.shellVariable-name | meta.main.key | meta.shellVariable.name | meta.inside-dict-settings | meta.inside-dict.settings.tmPreferences | meta.inside-dict - meta.inside-value - meta.inside-dict-key",
 }

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-settings
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-settings
@@ -1,4 +1,4 @@
 {
     "extensions": ["tmPreferences"],
-    "auto_complete_selector": "meta.tag - punctuation.definition.tag.begin.xml | meta.settings-key-wrapper | meta.inside-value.string.shellVariable-name | meta.main-key-wrapper | meta.shellVariable-name.wrapper | meta.inside-dict-settings | meta.inside-dict.settings.tmPreferences | meta.inside-dict - meta.inside-value - meta.inside-dict-key",
+    "auto_complete_selector": "meta.tag - punctuation.definition.tag.begin.xml | meta.settings.key | meta.inside-value.string.shellVariable-name | meta.main.key | meta.shellVariable-name.wrapper | meta.inside-dict-settings | meta.inside-dict.settings.tmPreferences | meta.inside-dict - meta.inside-value - meta.inside-dict-key",
 }

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
@@ -73,6 +73,9 @@ contexts:
     - match: '>'
       scope: punctuation.definition.tag.end.xml
       set: inside-main-dict
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
+      set: inside-main-dict
     - include: tag-end-self-closing
 
   inside-main-dict:
@@ -95,7 +98,9 @@ contexts:
         1: invalid.illegal.self-closing.xml
         2: punctuation.definition.tag.end.xml
       set: inside-main-dict-key
-    - include: tag-end-missing-pop
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
+      set: inside-main-dict-key
 
   inside-main-dict-key:
     - meta_scope: meta.main.key.tmPreferences
@@ -151,6 +156,9 @@ contexts:
     - match: '>'
       scope: punctuation.definition.tag.end.xml
       set: inside-settings-dict
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
+      set: inside-settings-dict
     - include: tag-end-self-closing
 
   inside-settings-dict:
@@ -173,7 +181,9 @@ contexts:
         1: invalid.illegal.self-closing.xml
         2: punctuation.definition.tag.end.xml
       set: inside-settings-dict-key
-    - include: tag-end-missing-pop
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
+      set: inside-settings-dict-key
 
   inside-settings-dict-key:
     - meta_scope: meta.settings.key.tmPreferences
@@ -247,6 +257,9 @@ contexts:
     - match: '>'
       scope: punctuation.definition.tag.end.xml
       set: inside-fold-scopes-array
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
+      set: inside-fold-scopes-array
     - include: tag-end-self-closing
 
   inside-fold-scopes-array:
@@ -266,6 +279,9 @@ contexts:
     - meta_scope: meta.tag.xml
     - match: '>'
       scope: punctuation.definition.tag.end.xml
+      set: inside-fold-scopes-dict
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
       set: inside-fold-scopes-dict
     - include: tag-end-self-closing
 
@@ -289,7 +305,9 @@ contexts:
         1: invalid.illegal.self-closing.xml
         2: punctuation.definition.tag.end.xml
       set: inside-fold-scopes-dict-key
-    - include: tag-end-missing-pop
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
+      set: inside-fold-scopes-dict-key
 
   inside-fold-scopes-dict-key:
     - meta_scope: meta.foldScopes.key.tmPreferences
@@ -332,6 +350,9 @@ contexts:
     - match: '>'
       scope: punctuation.definition.tag.end.xml
       set: inside-shell-variables-array
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
+      set: inside-shell-variables-array
     - include: tag-end-self-closing
 
   inside-shell-variables-array:
@@ -351,6 +372,9 @@ contexts:
     - meta_scope: meta.tag.xml
     - match: '>'
       scope: punctuation.definition.tag.end.xml
+      set: inside-shell-variables-dict
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
       set: inside-shell-variables-dict
     - include: tag-end-self-closing
 
@@ -374,7 +398,9 @@ contexts:
         1: invalid.illegal.self-closing.xml
         2: punctuation.definition.tag.end.xml
       set: inside-shell-variables-dict-key
-    - include: tag-end-missing-pop
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
+      set: inside-shell-variables-dict-key
 
   inside-shell-variables-dict-key:
     - meta_scope: meta.shellVariable.key.tmPreferences
@@ -383,7 +409,7 @@ contexts:
     - match: name\b
       scope: meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences
       set:
-        - expect-shell-variable-name
+        - expect-shell-variable-name-value
         - shell-variables-dict-key-meta
         - expect-key-end
     - match: value\b
@@ -403,23 +429,32 @@ contexts:
     - meta_content_scope: meta.shellVariable.key.tmPreferences
     - include: immediately-pop
 
-  expect-shell-variable-name:
+  expect-shell-variable-name-value:
     - match: (<)(string){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-      set: shell-variable-name-tag
+      set:
+        - shell-variables-name-value-meta
+        - shell-variable-name-value-tag
     - include: expect-value-end
 
-  shell-variable-name-tag:
-    - meta_scope: meta.shellVariable.name.tmPreferences meta.tag.xml
+  shell-variables-name-value-meta:
+    - meta_include_prototype: false
+    - meta_scope: meta.shellVariable.name.tmPreferences
+    - include: immediately-pop
+
+  shell-variable-name-value-tag:
+    - meta_scope: meta.tag.xml
     - match: '>'
       scope: punctuation.definition.tag.end.xml
-      set: inside-shell-variable-name
+      set: inside-shell-variable-name-value
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
+      set: inside-shell-variable-name-value
     - include: tag-end-self-closing
 
-  inside-shell-variable-name:
-    - meta_scope: meta.shellVariable.name.tmPreferences
+  inside-shell-variable-name-value:
     - meta_content_scope: meta.inside-value.string.plist
     - include: string-end
     - include: value-content
@@ -453,7 +488,9 @@ contexts:
         1: invalid.illegal.self-closing.xml
         2: punctuation.definition.tag.end.xml
       set: inside-integer-string
-    - include: tag-end-missing-pop
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
+      set: inside-integer-string
 
   inside-integer-string:
     - meta_content_scope: meta.inside-value.string.plist
@@ -479,6 +516,9 @@ contexts:
     - meta_scope: meta.tag.xml
     - match: '>'
       scope: punctuation.definition.tag.end.xml
+      set: inside-scope-string
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
       set: inside-scope-string
     - include: tag-end-self-closing
 
@@ -538,6 +578,9 @@ contexts:
     - match: '>'
       scope: punctuation.definition.tag.end.xml
       set: inside-regexp-string
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
+      set: inside-regexp-string
     - include: tag-end-self-closing
 
   inside-regexp-string:
@@ -584,6 +627,9 @@ contexts:
     - meta_scope: meta.tag.xml
     - match: '>'
       scope: punctuation.definition.tag.end.xml
+      set: inside-transformation-string
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
       set: inside-transformation-string
     - include: tag-end-self-closing
 
@@ -651,6 +697,9 @@ contexts:
     - meta_scope: meta.tag.xml
     - match: '>'
       scope: punctuation.definition.tag.end.xml
+      set: [inside-string-value, maybe-comments]
+    - match: \s?(?=<)
+      scope: invalid.illegal.missing-tag-end.xml
       set: [inside-string-value, maybe-comments]
     - include: tag-end-self-closing
 

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
@@ -89,7 +89,7 @@ contexts:
     - include: whitespace-or-tags
 
   inside-main-dict-key-tag:
-    - meta_scope: meta.main-key-wrapper.tmPreferences meta.tag.xml
+    - meta_scope: meta.main.key.tmPreferences meta.tag.xml
     - match: (/?)(>)
       captures:
         1: invalid.illegal.self-closing.xml
@@ -98,7 +98,7 @@ contexts:
     - include: tag-end-missing-pop
 
   inside-main-dict-key:
-    - meta_scope: meta.main-key-wrapper.tmPreferences
+    - meta_scope: meta.main.key.tmPreferences
     - meta_content_scope: meta.inside-dict-key.plist
     - include: comments
     - match: name\b
@@ -133,7 +133,7 @@ contexts:
 
   main-dict-key-meta:
     - meta_include_prototype: false
-    - meta_content_scope: meta.main-key-wrapper.tmPreferences
+    - meta_content_scope: meta.main.key.tmPreferences
     - include: immediately-pop
 
 ###[ SETTINGS DICT ]###########################################################
@@ -167,7 +167,7 @@ contexts:
     - include: whitespace-or-tags
 
   inside-settings-dict-key-tag:
-    - meta_scope: meta.settings-key-wrapper.tmPreferences meta.tag.xml
+    - meta_scope: meta.settings.key.tmPreferences meta.tag.xml
     - match: (/?)(>)
       captures:
         1: invalid.illegal.self-closing.xml
@@ -176,7 +176,7 @@ contexts:
     - include: tag-end-missing-pop
 
   inside-settings-dict-key:
-    - meta_scope: meta.settings-key-wrapper.tmPreferences
+    - meta_scope: meta.settings.key.tmPreferences
     - meta_content_scope: meta.inside-dict-key.plist
     - include: comments
     - match: foldScopes\b
@@ -229,7 +229,7 @@ contexts:
 
   settings-dict-key-meta:
     - meta_include_prototype: false
-    - meta_content_scope: meta.settings-key-wrapper.tmPreferences
+    - meta_content_scope: meta.settings.key.tmPreferences
     - include: immediately-pop
 
 ###[ SETTINGS / FOLDSCOPES ARRAY ]#############################################
@@ -283,7 +283,7 @@ contexts:
     - include: whitespace-or-tags
 
   inside-fold-scopes-dict-key-tag:
-    - meta_scope: meta.foldScopes-key-wrapper.tmPreferences meta.tag.xml
+    - meta_scope: meta.foldScopes.key.tmPreferences meta.tag.xml
     - match: (/?)(>)
       captures:
         1: invalid.illegal.self-closing.xml
@@ -292,7 +292,7 @@ contexts:
     - include: tag-end-missing-pop
 
   inside-fold-scopes-dict-key:
-    - meta_scope: meta.foldScopes-key-wrapper.tmPreferences
+    - meta_scope: meta.foldScopes.key.tmPreferences
     - meta_content_scope: meta.inside-dict-key.plist
     - match: (?:begin|end)\b
       scope: meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences
@@ -314,7 +314,7 @@ contexts:
 
   fold-scopes-dict-key-meta:
     - meta_include_prototype: false
-    - meta_content_scope: meta.foldScopes-key-wrapper.tmPreferences
+    - meta_content_scope: meta.foldScopes.key.tmPreferences
     - include: immediately-pop
 
 ###[ SETTINGS / SHELLVARIABLES ARRAY ]#########################################
@@ -368,7 +368,7 @@ contexts:
     - include: whitespace-or-tags
 
   inside-shell-variables-dict-key-tag:
-    - meta_scope: meta.shellVariable-key-wrapper.tmPreferences meta.tag.xml
+    - meta_scope: meta.shellVariable.key.tmPreferences meta.tag.xml
     - match: (/?)(>)
       captures:
         1: invalid.illegal.self-closing.xml
@@ -377,7 +377,7 @@ contexts:
     - include: tag-end-missing-pop
 
   inside-shell-variables-dict-key:
-    - meta_scope: meta.shellVariable-key-wrapper.tmPreferences
+    - meta_scope: meta.shellVariable.key.tmPreferences
     - meta_content_scope: meta.inside-dict-key.plist
     - include: comments
     - match: name\b
@@ -400,7 +400,7 @@ contexts:
 
   shell-variables-dict-key-meta:
     - meta_include_prototype: false
-    - meta_content_scope: meta.shellVariable-key-wrapper.tmPreferences
+    - meta_content_scope: meta.shellVariable.key.tmPreferences
     - include: immediately-pop
 
   expect-shell-variable-name:

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
@@ -1,619 +1,704 @@
 %YAML 1.2
 ---
 name: TextMate Preferences (PList / XML)
+scope: text.xml.plist.textmate.preferences
+version: 2
+
+extends: Packages/PackageDev/Package/Property List/Property List.sublime-syntax
+
 file_extensions:
   - tmPreferences
   - hidden-tmPreferences
-scope: text.xml.plist.textmate.preferences
+
+variables:
+
+  boolean_settings: |-
+    (?x: indentParens
+    | indentationFoldingEnabled
+    | indentSquareBrackets
+    | preserveIndent
+    | scopeFoldingEnabled )
+  integer_settings: |-
+    (?x: showInSymbolList
+    | showInIndexedSymbolList
+    | showInIndexedReferenceList )
+  regexp_settings: |-
+    (?x: batchDecreaseIndentPattern
+    | batchIncreaseIndentPattern
+    | bracketIndentNextLinePattern
+    | cancelCompletion
+    | decreaseIndentPattern
+    | disableIndentNextLinePattern
+    | increaseIndentPattern
+    | unIndentedLinePattern )
+  string_settings: |-
+    (?x: icon )
+  transformation_settings: |-
+    (?x: symbolTransformation | symbolIndexTransformation )
 
 contexts:
 
-  main:
-    - include: scope:text.xml.plist#xml-declarations
-    - match: '(<)(plist)\s*(?:(version)\s*(=)\s*((")1.0(")))\s*(>)'
-      scope: meta.tag.xml
-      captures:
-        1: punctuation.definition.tag.begin
-        2: entity.name.tag.localname.xml
-        3: entity.other.attribute-name.localname.xml
-        4: punctuation.separator.key-value.xml
-        5: string.quoted.double.xml
-        6: punctuation.definition.string.begin.xml
-        7: punctuation.definition.string.end.xml
-        8: punctuation.definition.tag.end
-      push:
-        - meta_content_scope: meta.inside-plist.plist
-        - include: comments
-        - match: '(</)(plist)\s*(>)'
-          scope: meta.tag.xml
-          captures:
-            1: punctuation.definition.tag.begin.xml
-            2: entity.name.tag.localname.xml
-            3: punctuation.definition.tag.end.xml
-          set: scope:text.xml.plist#whitespace-or-tag
-        - match: '(<)(dict)\s*(>)'
-          scope: meta.tag.xml
-          captures:
-            1: punctuation.definition.tag.begin.xml
-            2: entity.name.tag.localname.xml
-            3: punctuation.definition.tag.end.xml
-          push: inside-outer-dict
-        # we only expect a dict
-        - match: '\S+'
-          scope: invalid.illegal.expected-dict.tmPreferences
-    - include: scope:text.xml.plist#whitespace-or-tag
+###[ PLIST OVERRIDES ]#########################################################
 
-  comments:
-    - include: scope:text.xml.plist#comments
+  maybe-comments:
+    - include: comments
+    - include: else-pop
 
-  any-known-element:
-    - include: scope:text.xml.plist#number
-    - include: scope:text.xml.plist#boolean
-    - include: scope:text.xml.plist#string
-    - include: scope:text.xml.plist#empty-array
+  inside-plist:
+    - meta_content_scope: meta.inside-plist.tmPreferences
+    - include: plist-end
+    - include: expect-main-dicts
+
+  any-element:
     # NOTE: we deliberately don't include "date", or "data" here as ST doesn't support them
-    - match: '(<)(dict)\s*(>)'
-      scope: meta.tag.xml
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      set: inside-any-dict
-    - match: '(<)(array)\s*(>)'
-      scope: meta.tag.xml
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      set: inside-array
-    - include: scope:text.xml.plist#whitespace-or-tag
+    - include: boolean
+    - include: number
+    - include: string
+    - include: dict
+    - include: array
+    - include: expect-value-end
 
-  array-end:
-    - include: comments
-    - match: '(</)(array)\s*(>)'
-      scope: meta.tag.xml
+###[ MAIN DICT ]###############################################################
+
+  expect-main-dicts:
+    - match: (<)(dict){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      pop: true
+      push: inside-main-dict-tag
+    - include: whitespace-or-tags
 
-  dict-end:
-    - include: comments
-    - match: '(</)(dict)\s*(>)'
-      scope: meta.tag.xml
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      pop: true
+  inside-main-dict-tag:
+    - meta_scope: meta.tag.xml
+    - match: '>'
+      scope: punctuation.definition.tag.end.xml
+      set: inside-main-dict
+    - include: tag-end-self-closing
 
-  key-end:
-    - include: comments
-    - match: '(</)(key)\s*(>)'
-      scope: meta.tag.xml
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      pop: true
-
-  string-end:
-    - include: comments
-    - match: '(</)(string)\s*(>)'
-      scope: meta.tag.xml
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      pop: true
-
-  inside-outer-dict:
-    - meta_content_scope: meta.inside-dict.plist
+  inside-main-dict:
+    - meta_content_scope: meta.inside-dict.main.tmPreferences
     - include: dict-end
+    - include: expect-main-dict-keys
 
-    - match: '(<)(key)\s*(>)'
-      scope: meta.tag.xml
+  expect-main-dict-keys:
+    - match: (<)(key){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      push:
-        - meta_scope: meta.main-key-wrapper.tmPreferences
-        - meta_content_scope: meta.inside-dict-key.plist
-        - include: key-end
-        - match: 'scope(?=\s*<)'
-          scope: keyword.other.scope.tmPreferences
-          set: [expect-scope-string, key-end]
-        - match: 'name(?=\s*<)'
-          scope: keyword.other.name.tmPreferences
-          set: [expect-string, key-end]
-        - match: 'settings(?=\s*<)'
-          scope: keyword.other.settings.tmPreferences
-          set: [settings, key-end]
-        - match: 'uuid(?=\s*<)'
-          scope: keyword.other.uuid.tmPreferences
-          set: [expect-string, key-end] # TODO validate uuid
+      push: inside-main-dict-key-tag
+    - include: whitespace-or-tags
 
-  settings:
-    - match: '(<)(dict)\s*(>)'
-      scope: meta.tag.xml
+  inside-main-dict-key-tag:
+    - meta_scope: meta.main-key-wrapper.tmPreferences meta.tag.xml
+    - match: (/?)(>)
+      captures:
+        1: invalid.illegal.self-closing.xml
+        2: punctuation.definition.tag.end.xml
+      set: inside-main-dict-key
+    - include: tag-end-missing-pop
+
+  inside-main-dict-key:
+    - meta_scope: meta.main-key-wrapper.tmPreferences
+    - meta_content_scope: meta.inside-dict-key.plist
+    - include: comments
+    - match: name\b
+      scope: meta.inside-dict-key.plist keyword.other.name.tmPreferences
+      set:
+        - expect-string
+        - main-dict-key-meta
+        - expect-key-end
+    - match: scope\b
+      scope: meta.inside-dict-key.plist keyword.other.scope.tmPreferences
+      set:
+        - expect-scope-string
+        - main-dict-key-meta
+        - expect-key-end
+    - match: settings\b
+      scope: meta.inside-dict-key.plist keyword.other.settings.tmPreferences
+      set:
+        - expect-settings-dict
+        - main-dict-key-meta
+        - expect-key-end
+    - match: uuid\b
+      scope: meta.inside-dict-key.plist keyword.other.uuid.tmPreferences
+      set:
+        - expect-string
+        - main-dict-key-meta
+        - expect-key-end
+    - match: (?=<)
+      set:
+        - any-element
+        - main-dict-key-meta
+        - expect-key-end
+
+  main-dict-key-meta:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.main-key-wrapper.tmPreferences
+    - include: immediately-pop
+
+###[ SETTINGS DICT ]###########################################################
+
+  expect-settings-dict:
+    - match: (<)(dict){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
+      set: inside-settings-dict-tag
+    - include: whitespace-or-tags
+
+  inside-settings-dict-tag:
+    - meta_scope: meta.tag.xml
+    - match: '>'
+      scope: punctuation.definition.tag.end.xml
       set: inside-settings-dict
-    - include: scope:text.xml.plist#whitespace-or-tag
+    - include: tag-end-self-closing
 
   inside-settings-dict:
     - meta_content_scope: meta.inside-dict.settings.tmPreferences
     - include: dict-end
+    - include: expect-settings-dict-keys
 
-    - match: '(<)(key)\s*(>)'
-      scope: meta.tag.xml
+  expect-settings-dict-keys:
+    - match: (<)(key){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      push:
-        - meta_scope: meta.settings-key-wrapper.tmPreferences
-        - meta_content_scope: meta.inside-dict-key.plist
-        - include: inside-dict-key
-        - match: 'foldScopes(?=\s*<)'
-          scope: keyword.other.foldScopes.tmPreferences
-          set: [fold-scopes, key-end]
-        - match: 'shellVariables(?=\s*<)'
-          scope: keyword.other.shellVariables.tmPreferences
-          set: [shell-variables, key-end]
-        - match: '(?:decreaseIndentPattern|batchDecreaseIndentPattern|increaseIndentPattern|batchIncreaseIndentPattern|disableIndentNextLinePattern|bracketIndentNextLinePattern|unIndentedLinePattern|cancelCompletion)(?=\s*<)'
-          scope: entity.name.constant.setting.regex.tmPreferences
-          set: [expect-regex-string, key-end]
-        - match: '(?:symbolTransformation|symbolIndexTransformation)(?=\s*<)'
-          scope: entity.name.constant.setting.regex-transform.tmPreferences
-          set: [expect-transformation-string, key-end]
-        - match: '(?:showInSymbolList|showInIndexedSymbolList|showInIndexedReferenceList)(?=\s*<)'
-          scope: entity.name.constant.setting.tmPreferences
-          set: [expect-integer, key-end] # yes, integer - for some reason, booleans don't work here
-        - match: '(?:indentParens|indentSquareBrackets|preserveIndent|indentationFoldingEnabled|scopeFoldingEnabled)(?=\s*<)'
-          scope: entity.name.constant.setting.tmPreferences
-          set: [expect-boolean, key-end]
-        - match: 'icon(?=\s*<)'
-          scope: entity.name.setting.tmPreferences
-          set: [expect-string, key-end]
+      push: inside-settings-dict-key-tag
+    - include: whitespace-or-tags
 
-    - include: inside-any-dict
-
-  inside-any-dict:
-    - meta_content_scope: meta.inside-dict.plist
-    - include: dict-end
-
-    - match: '(<)(key)\s*(>)'
-      scope: meta.tag.xml
+  inside-settings-dict-key-tag:
+    - meta_scope: meta.settings-key-wrapper.tmPreferences meta.tag.xml
+    - match: (/?)(>)
       captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      push: inside-dict-key
-    - include: scope:text.xml.plist#whitespace-or-tag
+        1: invalid.illegal.self-closing.xml
+        2: punctuation.definition.tag.end.xml
+      set: inside-settings-dict-key
+    - include: tag-end-missing-pop
 
-  inside-dict-key:
-    - meta_content_scope: meta.inside-dict-key.plist meta.dict-key-unknown.tmPreferences
+  inside-settings-dict-key:
+    - meta_scope: meta.settings-key-wrapper.tmPreferences
+    - meta_content_scope: meta.inside-dict-key.plist
     - include: comments
-    - match: '(<)(/)(key)\s*(>)'
-      scope: meta.tag.xml
-      captures:
-        1: meta.close-unknown-dict-key-tag.tmPreferences punctuation.definition.tag.begin.xml
-        2: punctuation.definition.tag.begin.xml
-        3: entity.name.tag.localname.xml
-        4: punctuation.definition.tag.end.xml
-      set: any-known-element
-    - match: '<'
-      scope: punctuation.definition.tag.begin.xml
-      push: scope:text.xml.plist#unknown-tag
-
-  expect-scope-string:
-    - match: '(<)(string)\s*(>)'
-      scope: meta.tag.xml
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
+    - match: foldScopes\b
+      scope: meta.inside-dict-key.plist keyword.other.foldScopes.tmPreferences
       set:
-        - meta_content_scope: meta.inside-value.string.plist
-        - match: (?=<!--)
-          push:
-            - match: (?!<!--)
-              pop: true
-            - include: scope:text.xml
-        - match: '(?=\S)'
-          set:
-            - meta_content_scope: meta.inside-value.string.plist meta.toc-list.scope.tmPreferences
-            - match: '<!\[CDATA\['
-              scope: string.unquoted.cdata.xml punctuation.definition.string.begin.xml
-              push:
-                - match: ']]>'
-                  scope: string.unquoted.cdata.xml punctuation.definition.string.end.xml
-                  set: st-end-of-string-handling
-                - include: scope:source.scope-selector
-            - match: '(</)(string)\s*(>)'
-              scope: meta.tag.xml
-              captures:
-                1: punctuation.definition.tag.begin.xml
-                2: entity.name.tag.localname.xml
-                3: punctuation.definition.tag.end.xml
-              pop: true
-            - match: '(?=\S)'
-              push:
-                - include: scope:source.scope-selector
-              with_prototype:
-                - match: '\s*((&)amp(;))\s*'
-                  captures:
-                    1: constant.character.entity.xml keyword.operator.with.scope-selector
-                    2: punctuation.definition.constant.xml
-                    3: punctuation.definition.constant.xml
-                - include: until-end-of-string
-                - match: '\s*(&)\s*'
-                  captures:
-                    1: invalid.illegal.bad-ampersand.xml
-    - include: scope:text.xml.plist#whitespace-or-tag
-
-  expect-regex-string:
-    - match: '(<)(string)\s*(>)'
-      scope: meta.tag.xml
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
+        - expect-fold-scopes-array
+        - settings-dict-key-meta
+        - expect-key-end
+    - match: shellVariables\b
+      scope: meta.inside-dict-key.plist keyword.other.shellVariables.tmPreferences
       set:
-        - meta_content_scope: meta.inside-value.string.plist
-        - match: (?=<!--)
-          push:
-            - match: (?!<!--)
-              pop: true
-            - include: scope:text.xml
-        - match: '(?=\S)'
-          set:
-            - meta_content_scope: meta.inside-value.string.plist
-            - match: '(</)(string)\s*(>)'
-              scope: meta.tag.xml
-              captures:
-                1: punctuation.definition.tag.begin.xml
-                2: entity.name.tag.localname.xml
-                3: punctuation.definition.tag.end.xml
-              pop: true
-            - match: '(?=<!\[CDATA\[)'
-              push:
-                - match: ']]>'
-                  scope: string.unquoted.cdata.xml punctuation.definition.string.end.xml
-                  set: st-end-of-string-handling
-                - match: '<!\[CDATA\['
-                  scope: string.unquoted.cdata.xml punctuation.definition.string.begin.xml
-                  push: regex-pattern
-                  with_prototype:
-                    - match: '(?=]]>)'
-                      pop: true
-            - match: '(?=\S)'
-              push: regex-pattern
-              with_prototype:
-                - include: until-end-of-string
-    - include: scope:text.xml.plist#whitespace-or-tag
-
-  expect-transformation-string:
-    - match: '(<)(string)\s*(>)'
-      scope: meta.tag.xml
-      captures:
-        1: punctuation.definition.tag.begin.xml
-        2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
+        - expect-shell-variables-array
+        - settings-dict-key-meta
+        - expect-key-end
+    - match: '{{regexp_settings}}\b'
+      scope: meta.inside-dict-key.plist entity.name.constant.setting.regexp.tmPreferences
       set:
-        - meta_content_scope: meta.inside-value.string.plist
-        - match: (?=<!--)
-          push:
-            - match: (?!<!--)
-              pop: true
-            - include: scope:text.xml
-        - match: '(?=\S)'
-          set:
-            - meta_content_scope: meta.inside-value.string.plist
-            - match: '(</)(string)\s*(>)'
-              scope: meta.tag.xml
-              captures:
-                1: punctuation.definition.tag.begin.xml
-                2: entity.name.tag.localname.xml
-                3: punctuation.definition.tag.end.xml
-              pop: true
-            - match: '(?=<!\[CDATA\[)'
-              push:
-                - match: ']]>'
-                  scope: string.unquoted.cdata.xml punctuation.definition.string.end.xml
-                  set: st-end-of-string-handling
-                - match: '<!\[CDATA\['
-                  scope: string.unquoted.cdata.xml punctuation.definition.string.begin.xml
-                  push: transformation
-                  with_prototype:
-                    - match: '(?=]]>)'
-                      pop: true
-            - match: '(?=\S)'
-              push: transformation
-              with_prototype:
-                - include: until-end-of-string
-    - include: scope:text.xml.plist#whitespace-or-tag
+        - expect-regexp-string
+        - settings-dict-key-meta
+        - expect-key-end
+    - match: '{{transformation_settings}}\b'
+      scope: meta.inside-dict-key.plist entity.name.constant.setting.regexp-transform.tmPreferences
+      set:
+        - expect-transformation-string
+        - settings-dict-key-meta
+        - expect-key-end
+    - match: '{{integer_settings}}\b'
+      scope: meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences
+      set:
+        - expect-integer
+        - settings-dict-key-meta
+        - expect-key-end
+    - match: '{{boolean_settings}}\b'
+      scope: meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences
+      set:
+        - expect-boolean
+        - settings-dict-key-meta
+        - expect-key-end
+    - match: '{{string_settings}}\b'
+      scope: meta.inside-dict-key.plist entity.name.setting.tmPreferences
+      set:
+        - expect-string
+        - settings-dict-key-meta
+        - expect-key-end
+    - match: (?=<)
+      set:
+        - any-element
+        - settings-dict-key-meta
+        - expect-key-end
 
-  transformation:
-    - meta_content_scope: meta.regex.transformation.tmPreferences
-    - match: 's?/'
-      scope: punctuation.definition.substitute-what.tmPreferences
-      push:
-        - meta_content_scope: source.regexp.oniguruma
-        - match: (?=/)
-          set:
-            - match: '/'
-              scope: punctuation.definition.substitute-with.tmPreferences
-              set:
-                - match: '(/)([gimsx-]*)(;|$)'
-                  captures:
-                    1: punctuation.definition.substitute-flags.tmPreferences
-                    2: storage.modifier.mode.regexp.transformation.tmPreferences
-                    3: punctuation.definition.substitution.end.tmPreferences
-                  pop: true
-                - include: scope:source.regexp-replacement
-        - include: Oniguruma RegExp.sublime-syntax#base-literal
-    - include: Oniguruma RegExp.sublime-syntax#group-comment
-    - include: Oniguruma RegExp.sublime-syntax#extended-patterns
+  settings-dict-key-meta:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.settings-key-wrapper.tmPreferences
+    - include: immediately-pop
 
-  regex-pattern:
-    - meta_content_scope: meta.regex.tmPreferences source.regexp.oniguruma
-    - include: scope:source.regexp.oniguruma
+###[ SETTINGS / FOLDSCOPES ARRAY ]#############################################
 
-  fold-scopes:
-    - include: comments
-    - match: '(<)(array)\s*(>)'
-      scope: meta.tag.xml
+  expect-fold-scopes-array:
+    - match: (<)(array){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
+      set: inside-fold-scopes-array-tag
+    - include: whitespace-or-tags
+
+  inside-fold-scopes-array-tag:
+    - meta_scope: meta.tag.xml
+    - match: '>'
+      scope: punctuation.definition.tag.end.xml
       set: inside-fold-scopes-array
-    - include: scope:text.xml.plist#whitespace-or-tag
+    - include: tag-end-self-closing
 
   inside-fold-scopes-array:
-    - meta_content_scope: meta.inside-array.plist
+    - meta_content_scope: meta.inside-array.foldScopes.tmPreferences
     - include: array-end
-    - include: fold-scopes-dict
-    - include: scope:text.xml.plist#whitespace-or-tag
+    - include: expect-fold-scopes-dicts
 
-  fold-scopes-dict:
-    - match: '(<)(dict)\s*(>)'
-      scope: meta.tag.xml
+  expect-fold-scopes-dicts:
+    - match: (<)(dict){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      push: inside-fold-scope-dict
+      push: inside-fold-scopes-dict-tag
+    - include: whitespace-or-tags
 
-  inside-fold-scope-dict:
+  inside-fold-scopes-dict-tag:
+    - meta_scope: meta.tag.xml
+    - match: '>'
+      scope: punctuation.definition.tag.end.xml
+      set: inside-fold-scopes-dict
+    - include: tag-end-self-closing
+
+  inside-fold-scopes-dict:
     - meta_content_scope: meta.inside-dict.foldScopes.tmPreferences
     - include: dict-end
-    - include: fold-scope-dict-keys
-    - include: scope:text.xml.plist#whitespace-or-tag
+    - include: expect-fold-scopes-dict-keys
 
-  fold-scope-dict-keys:
-    - match: '((<)(key)\s*(>))(\s*(?:begin|end)\s*)((</)(key)\s*(>))'
-      captures:
-        1: meta.tag.xml
-        2: punctuation.definition.tag.begin.xml
-        3: entity.name.tag.localname.xml
-        4: punctuation.definition.tag.end.xml
-        5: meta.inside-dict-key.plist
-        6: meta.tag.xml
-        7: punctuation.definition.tag.begin.xml
-        8: entity.name.tag.localname.xml
-        9: punctuation.definition.tag.end.xml
-      push: fold-scope-value
-    - match: '((<)(key)\s*(>))(\s*(?:excludeTrailingNewlines)\s*)((</)(key)\s*(>))'
-      captures:
-        1: meta.tag.xml
-        2: punctuation.definition.tag.begin.xml
-        3: entity.name.tag.localname.xml
-        4: punctuation.definition.tag.end.xml
-        5: meta.inside-dict-key.plist
-        6: meta.tag.xml
-        7: punctuation.definition.tag.begin.xml
-        8: entity.name.tag.localname.xml
-        9: punctuation.definition.tag.end.xml
-      push: expect-boolean
-
-  fold-scope-value:
-    - match: '((<)(string)\s*(>))'
-      captures:
-        1: meta.tag.xml
-        2: punctuation.definition.tag.begin.xml
-        3: entity.name.tag.localname.xml
-        4: punctuation.definition.tag.end.xml
-      set: inside-fold-scope-value
-    - match: (?=</(?:array|dict)\s*>)
-      pop: true
-    - include: scope:text.xml.plist#whitespace-or-tag
-
-  inside-fold-scope-value:
-    - meta_scope: meta.scope-name.tmPreferences
-    - include: string-end
-    - include: scope:text.xml.plist#tag-end-missing-pop
-    - include: scope:source.scope-selector
-
-  shell-variables:
-    - include: comments
-    - match: '(<)(array)\s*(>)'
-      scope: meta.tag.xml
+  expect-fold-scopes-dict-keys:
+    - match: (<)(key){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
+      push: inside-fold-scopes-dict-key-tag
+    - include: whitespace-or-tags
+
+  inside-fold-scopes-dict-key-tag:
+    - meta_scope: meta.foldScopes-key-wrapper.tmPreferences meta.tag.xml
+    - match: (/?)(>)
+      captures:
+        1: invalid.illegal.self-closing.xml
+        2: punctuation.definition.tag.end.xml
+      set: inside-fold-scopes-dict-key
+    - include: tag-end-missing-pop
+
+  inside-fold-scopes-dict-key:
+    - meta_scope: meta.foldScopes-key-wrapper.tmPreferences
+    - meta_content_scope: meta.inside-dict-key.plist
+    - match: (?:begin|end)\b
+      scope: meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences
+      set:
+        - expect-scope-string
+        - fold-scopes-dict-key-meta
+        - expect-key-end
+    - match: excludeTrailingNewlines\b
+      scope: meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences
+      set:
+        - expect-boolean
+        - fold-scopes-dict-key-meta
+        - expect-key-end
+    - match: (?=<)
+      set:
+        - any-element
+        - fold-scopes-dict-key-meta
+        - expect-key-end
+
+  fold-scopes-dict-key-meta:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.foldScopes-key-wrapper.tmPreferences
+    - include: immediately-pop
+
+###[ SETTINGS / SHELLVARIABLES ARRAY ]#########################################
+
+  expect-shell-variables-array:
+    - match: (<)(array){{tag_name_break}}
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+      set: inside-shell-variables-array-tag
+    - include: whitespace-or-tags
+
+  inside-shell-variables-array-tag:
+    - meta_scope: meta.tag.xml
+    - match: '>'
+      scope: punctuation.definition.tag.end.xml
       set: inside-shell-variables-array
-    - include: scope:text.xml.plist#whitespace-or-tag
+    - include: tag-end-self-closing
 
   inside-shell-variables-array:
-    - meta_content_scope: meta.inside-array.plist
+    - meta_content_scope: meta.inside-array.shellVariables.tmPreferences
     - include: array-end
-    - match: '(<)(dict)\s*(>)'
-      scope: meta.tag.xml
+    - include: expect-shell-variables-dicts
+
+  expect-shell-variables-dicts:
+    - match: (<)(dict){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
-      push: inside-shell-variables-dict
-    - include: scope:text.xml.plist#whitespace-or-tag
+      push: inside-shell-variables-dict-tag
+    - include: whitespace-or-tags
+
+  inside-shell-variables-dict-tag:
+    - meta_scope: meta.tag.xml
+    - match: '>'
+      scope: punctuation.definition.tag.end.xml
+      set: inside-shell-variables-dict
+    - include: tag-end-self-closing
 
   inside-shell-variables-dict:
     - meta_content_scope: meta.inside-dict.shellVariables.tmPreferences
     - include: dict-end
+    - include: expect-shell-variables-dict-keys
 
-    - match: '((<)(key)\s*(>))(\s*name\s*)((</)(key)\s*(>))'
-      captures:
-        1: meta.tag.xml
-        2: punctuation.definition.tag.begin.xml
-        3: entity.name.tag.localname.xml
-        4: punctuation.definition.tag.end.xml
-        5: meta.inside-dict-key.plist
-        6: meta.tag.xml
-        7: punctuation.definition.tag.begin.xml
-        8: entity.name.tag.localname.xml
-        9: punctuation.definition.tag.end.xml
-      push: shell-variable-name-value
-    - match: '((<)(key)\s*(>))(\s*value\s*)((</)(key)\s*(>))'
-      captures:
-        1: meta.tag.xml
-        2: punctuation.definition.tag.begin.xml
-        3: entity.name.tag.localname.xml
-        4: punctuation.definition.tag.end.xml
-        5: meta.inside-dict-key.plist
-        6: meta.tag.xml
-        7: punctuation.definition.tag.begin.xml
-        8: entity.name.tag.localname.xml
-        9: punctuation.definition.tag.end.xml
-      push: expect-string
-    - match: '((<)(key)\s*(>))'
-      captures:
-        1: meta.tag.xml
-        2: punctuation.definition.tag.begin.xml
-        3: entity.name.tag.localname.xml
-        4: punctuation.definition.tag.end.xml
-      push: [expect-string, shell-variables-key-expect-name-or-value]
-    - include: scope:text.xml.plist#whitespace-or-tag
-
-  shell-variable-name-value:
-    - match: '((<)(string)\s*(>))(\s*((TM_COMMENT_(?:START|END|DISABLE_INDENT)(?:_[2-9])?)|(?:[^<]*))\s*)((</)(string)\s*(>))'
-      scope: meta.shellVariable-name.wrapper.tmPreferences
-      captures:
-        1: meta.tag.xml
-        2: punctuation.definition.tag.begin.xml
-        3: entity.name.tag.localname.xml
-        4: punctuation.definition.tag.end.xml
-        5: meta.inside-value.string.plist
-        6: entity.name.constant.shellVariable.tmPreferences
-        7: support.type.shellVariable.tmPreferences
-        8: meta.tag.xml
-        9: punctuation.definition.tag.begin.xml
-        10: entity.name.tag.localname.xml
-        11: punctuation.definition.tag.end.xml
-      pop: true
-    # don't escalate illegal highlighting beyond array or dictionary boundaries
-    - match: (?=</(?:array|dict)\s*>)
-      pop: true
-    - include: scope:text.xml.plist#whitespace-or-tag
-
-  shell-variables-key-expect-name-or-value:
-    - meta_content_scope: invalid.deprecated.expected-name-or-value.tmPreferences
-    - include: key-end
-
-  expect-boolean:
-    - include: scope:text.xml.plist#boolean
-    - include: scope:text.xml.plist#whitespace-or-tag
-
-  expect-integer:
-    - include: scope:text.xml.plist#number
-    - match: '((<)(string)\s*(>))(\s*([01])\s*)((</)(string)\s*(>))'
-      captures:
-        1: meta.tag.xml
-        2: punctuation.definition.tag.begin.xml
-        3: entity.name.tag.localname.xml
-        4: punctuation.definition.tag.end.xml
-        5: meta.inside-dict-key.plist
-        6: constant.numeric.tmPreferences
-        7: meta.tag.xml
-        8: punctuation.definition.tag.begin.xml
-        9: entity.name.tag.localname.xml
-        10: punctuation.definition.tag.end.xml
-      pop: true
-    - include: scope:text.xml.plist#whitespace-or-tag
-
-  expect-string:
-    - match: '(<)(string)\s*(>)'
-      scope: meta.tag.xml
+  expect-shell-variables-dict-keys:
+    - match: (<)(key){{tag_name_break}}
       captures:
         1: punctuation.definition.tag.begin.xml
         2: entity.name.tag.localname.xml
-        3: punctuation.definition.tag.end.xml
+      push: inside-shell-variables-dict-key-tag
+    - include: whitespace-or-tags
+
+  inside-shell-variables-dict-key-tag:
+    - meta_scope: meta.shellVariable-key-wrapper.tmPreferences meta.tag.xml
+    - match: (/?)(>)
+      captures:
+        1: invalid.illegal.self-closing.xml
+        2: punctuation.definition.tag.end.xml
+      set: inside-shell-variables-dict-key
+    - include: tag-end-missing-pop
+
+  inside-shell-variables-dict-key:
+    - meta_scope: meta.shellVariable-key-wrapper.tmPreferences
+    - meta_content_scope: meta.inside-dict-key.plist
+    - include: comments
+    - match: name\b
+      scope: meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences
       set:
-        - meta_content_scope: meta.inside-value.string.plist
-        - match: (?=<!--)
-          push:
-            - match: (?!<!--)
-              pop: true
-            - include: scope:text.xml
-        - match: '(?=\S)'
-          set:
-            - meta_content_scope: meta.inside-value.string.plist
-            - include: handle-comments-until-end-of-string
-            - match: '(</)(string)\s*(>)'
-              scope: meta.tag.xml
-              captures:
-                1: punctuation.definition.tag.begin.xml
-                2: entity.name.tag.localname.xml
-                3: punctuation.definition.tag.end.xml
-              pop: true
-            - match: '<(?!!)'
-              scope: punctuation.definition.tag.begin.xml
-              push: scope:text.xml.plist#unknown-tag
-            - include: scope:text.xml
-    - include: scope:text.xml.plist#whitespace-or-tag
+        - expect-shell-variable-name
+        - shell-variables-dict-key-meta
+        - expect-key-end
+    - match: value\b
+      scope: meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences
+      set:
+        - expect-string
+        - shell-variables-dict-key-meta
+        - expect-key-end
+    - match: (?=<)
+      set:
+        - any-element
+        - shell-variables-dict-key-meta
+        - expect-key-end
+
+  shell-variables-dict-key-meta:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.shellVariable-key-wrapper.tmPreferences
+    - include: immediately-pop
+
+  expect-shell-variable-name:
+    - match: (<)(string){{tag_name_break}}
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+      set: shell-variable-name-tag
+    - include: expect-value-end
+
+  shell-variable-name-tag:
+    - meta_scope: meta.shellVariable-name.wrapper.tmPreferences meta.tag.xml
+    - match: '>'
+      scope: punctuation.definition.tag.end.xml
+      set: inside-shell-variable-name
+    - include: tag-end-self-closing
+
+  inside-shell-variable-name:
+    - meta_scope: meta.shellVariable-name.wrapper.tmPreferences
+    - meta_content_scope: meta.inside-value.string.plist
+    - include: string-end
+    - include: value-content
+    - include: comments
+    - match: \bTM_COMMENT_(?:START|END|DISABLE_INDENT)(?:_[2-9])?\b
+      scope: entity.name.constant.shellVariable.tmPreferences support.constant.shellVariable.tmPreferences
+      push: after-number
+    - match: \b\w+\b
+      scope: entity.name.constant.shellVariable.tmPreferences
+      push: after-number
+
+###[ SETTINGS / SCALAR VALUES ]################################################
+
+  expect-boolean:
+    - include: boolean
+    - include: expect-value-end
+
+  expect-integer:
+    - match: (<)(string){{tag_name_break}}
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+      set: inside-integer-string-tag
+    - include: integer
+    - include: expect-value-end
+
+  inside-integer-string-tag:
+    - meta_scope: meta.tag.xml
+    - match: (/?)(>)
+      captures:
+        1: invalid.illegal.self-closing.xml
+        2: punctuation.definition.tag.end.xml
+      set: inside-integer-string
+    - include: tag-end-missing-pop
+
+  inside-integer-string:
+    - meta_content_scope: meta.inside-value.string.plist
+    - include: string-end
+    - include: value-bailout
+    - match: '[01]'
+      scope: constant.numeric.tmPreferences
+      push: after-number
+    - match: '[^\s<]+'
+      scope: invalid.illegal.expected-number.tmPreferences
+
+###[ SETTINGS / SCOPE VALUES ]#################################################
+
+  expect-scope-string:
+    - match: (<)(string){{tag_name_break}}
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+      set: inside-scope-string-tag
+    - include: expect-value-end
+
+  inside-scope-string-tag:
+    - meta_scope: meta.tag.xml
+    - match: '>'
+      scope: punctuation.definition.tag.end.xml
+      set: inside-scope-string
+    - include: tag-end-self-closing
+
+  inside-scope-string:
+    - meta_content_scope: meta.inside-value.string.plist
+    - include: string-end
+    - include: value-bailout
+    - include: comments
+    - match: (<!\[)(CDATA)(\[)
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: keyword.declaration.cdata.xml
+        3: punctuation.definition.tag.begin.xml
+      push: inside-scope-selector-cdata
+    - match: (?=\S)
+      push: scope-selector
+      with_prototype:
+        - include: scope-selecotr-prototypes
+
+  inside-scope-selector-cdata:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.sgml.cdata.xml
+    - match: ']]>'
+      scope: punctuation.definition.tag.end.xml
+      set: st-end-of-string-handling
+    - match: ''
+      embed: scope-selector
+      escape: (?=]]>)
+
+  scope-selector:
+    - meta_content_scope: meta.string.selector.tmPreferences
+    - include: scope:source.scope-selector
+
+  scope-selecotr-prototypes:
+    - match: \s*((&)amp(;))\s*
+      captures:
+        1: constant.character.entity.xml keyword.operator.with.scope-selector
+        2: punctuation.definition.constant.xml
+        3: punctuation.definition.constant.xml
+    - match: \s*(&)\s*
+      captures:
+        1: invalid.illegal.bad-ampersand.xml
+    - include: until-end-of-string
+
+###[ SETTINGS / REGEXP VALUES ]################################################
+
+  expect-regexp-string:
+    - match: (<)(string){{tag_name_break}}
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+      set: inside-regexp-string-tag
+    - include: expect-value-end
+
+  inside-regexp-string-tag:
+    - meta_scope: meta.tag.xml
+    - match: '>'
+      scope: punctuation.definition.tag.end.xml
+      set: inside-regexp-string
+    - include: tag-end-self-closing
+
+  inside-regexp-string:
+    - meta_content_scope: meta.inside-value.string.plist
+    - include: string-end
+    - include: value-bailout
+    - include: comments
+    - match: (<!\[)(CDATA)(\[)
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: keyword.declaration.cdata.xml
+        3: punctuation.definition.tag.begin.xml
+      push: inside-regexp-cdata
+    - match: (?=\S)
+      push: regexp-pattern
+      with_prototype:
+        - include: until-end-of-string
+
+  inside-regexp-cdata:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.sgml.cdata.xml
+    - match: ']]>'
+      scope: punctuation.definition.tag.end.xml
+      set: st-end-of-string-handling
+    - match: ''
+      embed: regexp-pattern
+      escape: (?=]]>)
+
+  regexp-pattern:
+    - meta_content_scope: meta.string.regexp.tmPreferences source.regexp.oniguruma
+    - include: scope:source.regexp.oniguruma
+
+###[ SETTINGS / TRANSFORMATION VALUES ]########################################
+
+  expect-transformation-string:
+    - match: (<)(string){{tag_name_break}}
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+      set: inside-transformation-string-tag
+    - include: expect-value-end
+
+  inside-transformation-string-tag:
+    - meta_scope: meta.tag.xml
+    - match: '>'
+      scope: punctuation.definition.tag.end.xml
+      set: inside-transformation-string
+    - include: tag-end-self-closing
+
+  inside-transformation-string:
+    - meta_content_scope: meta.inside-value.string.plist
+    - include: string-end
+    - include: value-bailout
+    - include: comments
+    - match: (<!\[)(CDATA)(\[)
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: keyword.declaration.cdata.xml
+        3: punctuation.definition.tag.begin.xml
+      push: inside-transformation-cdata
+    - match: (?=\S)
+      push: transformations
+      with_prototype:
+        - include: until-end-of-string
+
+  inside-transformation-cdata:
+    - meta_include_prototype: false
+    - meta_scope: meta.tag.sgml.cdata.xml
+    - match: ']]>'
+      scope: punctuation.definition.tag.end.xml
+      set: st-end-of-string-handling
+    - match: ''
+      embed: transformations
+      escape: (?=]]>)
+
+  transformations:
+    - meta_content_scope: meta.string.regexp.transformation.tmPreferences
+    - match: s?/
+      scope: punctuation.definition.substitute-what.tmPreferences
+      push: transformation-subst-pattern
+    - include: Oniguruma RegExp.sublime-syntax#group-comment
+    - include: Oniguruma RegExp.sublime-syntax#extended-patterns
+
+  transformation-subst-pattern:
+    - meta_content_scope: source.regexp.oniguruma
+    - match: /
+      scope: punctuation.definition.substitute-with.tmPreferences
+      set: transformation-subst-replacement
+    - include: Oniguruma RegExp.sublime-syntax#base-literal
+
+  transformation-subst-replacement:
+    - match: (/)([gimsx-]*)(;|$)
+      captures:
+        1: punctuation.definition.substitute-flags.tmPreferences
+        2: storage.modifier.mode.regexp.transformation.tmPreferences
+        3: punctuation.definition.substitution.end.tmPreferences
+      pop: 1
+    - include: scope:source.regexp-replacement
+
+###[ SETTINGS / STRING VALUES ]################################################
+
+  expect-string:
+    - match: (<)(string){{tag_name_break}}
+      captures:
+        1: punctuation.definition.tag.begin.xml
+        2: entity.name.tag.localname.xml
+      set: inside-string-value-tag
+    - include: expect-value-end
+
+  inside-string-value-tag:
+    - meta_scope: meta.tag.xml
+    - match: '>'
+      scope: punctuation.definition.tag.end.xml
+      set: [inside-string-value, maybe-comments]
+    - include: tag-end-self-closing
+
+  inside-string-value:
+    - meta_content_scope: meta.inside-value.string.plist
+    - include: handle-comments-until-end-of-string
+    - include: inside-string
 
   handle-comments-until-end-of-string:
-    - match: '(?=<!--)'
+    - match: (?=<!--)
       push: st-end-of-string-handling
 
   st-end-of-string-handling:
-    - match: '(?=</string\s*>)'
-      pop: true
-    - match: '(?=<!\[CDATA\[)'
-      push:
-        - meta_scope: invalid.deprecated.ignored-after-comment-or-cdata.tmPreferences
-        - match: '(?!<!\[CDATA\[)'
-          pop: true
-        - include: scope:text.xml
-    - match: '<(?!!)'
-      scope: punctuation.definition.tag.begin.xml
-      push: scope:text.xml.plist#unknown-tag
-    - include: scope:text.xml
-    - match: '[^<\s]+|\s+(?![\s<])'
-      scope: invalid.deprecated.ignored-after-comment-or-cdata.tmPreferences
+    - meta_content_scope: invalid.deprecated.ignored-after-comment-or-cdata.tmPreferences
+    - match: (?=\s*</string{{tag_name_break}})
+      pop: 1
+    - include: value-content
 
   until-end-of-string:
+    - match: (?=\s*</string{{tag_name_break}})
+      pop: 1
+    - include: value-bailout
     - include: handle-comments-until-end-of-string
-    - match: '(?=</string\s*>|<!\[CDATA\[)'
-      pop: true
-    - include: scope:text.xml#entity
-    - include: scope:text.xml#should-be-entity
-    - match: '(\\)([<>])'
+    - include: entity
+    - include: should-be-entity
+    - match: (\\)([<>])
       captures:
         1: constant.character.escape.regexp
         2: constant.character.escape.regexp invalid.illegal.missing-entity.xml
-    - match: '\(\?([<>])'
+    - match: \(\?([<>])
       captures:
         1: invalid.illegal.missing-entity.xml
 
-  inside-array:
-    - meta_content_scope: meta.inside-array.plist
-    - include: array-end
+###[ PROTOTYPES ]##############################################################
+
+  expect-key-end:
+    - meta_content_scope: meta.inside-dict-key.plist
+    - include: key-end
+    - include: expect-value-end
+
+  expect-value-end:
+    - include: value-bailout
+    - include: whitespace-or-tags
+
+  else-pop:
     - match: (?=\S)
-      push: any-known-element
+      pop: 1
+
+  immediately-pop:
+    - match: ''
+      pop: 1

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
@@ -412,14 +412,14 @@ contexts:
     - include: expect-value-end
 
   shell-variable-name-tag:
-    - meta_scope: meta.shellVariable-name.wrapper.tmPreferences meta.tag.xml
+    - meta_scope: meta.shellVariable.name.tmPreferences meta.tag.xml
     - match: '>'
       scope: punctuation.definition.tag.end.xml
       set: inside-shell-variable-name
     - include: tag-end-self-closing
 
   inside-shell-variable-name:
-    - meta_scope: meta.shellVariable-name.wrapper.tmPreferences
+    - meta_scope: meta.shellVariable.name.tmPreferences
     - meta_content_scope: meta.inside-value.string.plist
     - include: string-end
     - include: value-content

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
@@ -216,7 +216,7 @@ contexts:
         - settings-dict-key-meta
         - expect-key-end
     - match: '{{string_settings}}\b'
-      scope: meta.inside-dict-key.plist entity.name.setting.tmPreferences
+      scope: meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences
       set:
         - expect-string
         - settings-dict-key-meta

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
@@ -534,34 +534,23 @@ contexts:
         3: punctuation.definition.tag.begin.xml
       push: inside-scope-selector-cdata
     - match: (?=\S)
-      push: scope-selector
-      with_prototype:
-        - include: scope-selecotr-prototypes
+      push: inside-scope-selector
 
   inside-scope-selector-cdata:
     - meta_include_prototype: false
     - meta_scope: meta.tag.sgml.cdata.xml
+    - meta_content_scope: meta.string.selector.tmPreferences
     - match: ']]>'
       scope: punctuation.definition.tag.end.xml
       set: st-end-of-string-handling
-    - match: ''
-      embed: scope-selector
-      escape: (?=]]>)
-
-  scope-selector:
-    - meta_content_scope: meta.string.selector.tmPreferences
     - include: scope:source.scope-selector
 
-  scope-selecotr-prototypes:
-    - match: \s*((&)amp(;))\s*
-      captures:
-        1: constant.character.entity.xml keyword.operator.with.scope-selector
-        2: punctuation.definition.constant.xml
-        3: punctuation.definition.constant.xml
-    - match: \s*(&)\s*
-      captures:
-        1: invalid.illegal.bad-ampersand.xml
-    - include: until-end-of-string
+  inside-scope-selector:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.selector.tmPreferences
+    - match: (?=\s*</|<!--)
+      set: st-end-of-string-handling
+    - include: scope:source.scope-selector.xml
 
 ###[ SETTINGS / REGEXP VALUES ]################################################
 

--- a/Package/TextMate Preferences/syntax_test_tmPreferences.xml
+++ b/Package/TextMate Preferences/syntax_test_tmPreferences.xml
@@ -236,10 +236,10 @@
 <!--                         ^^^^^ meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences -->
 <!--                              ^^^^^^ meta.tag.xml - meta.inside-dict-key -->
 <!--                                ^^^ entity.name.tag.localname.xml -->
-                        <string>punctuation.section.group.begin</string>
-<!--                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-dict.foldScopes.tmPreferences -->
+                        <string>punctuation.section.group.begin &amp; ( invalid </string>
+<!--                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-dict.foldScopes.tmPreferences -->
 <!--                    ^^^^^^^^ meta.tag.xml - meta.inside-value -->
-<!--                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist -->
+<!--                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist -->
 <!--                            ^^^^^^^^^^^ string.unquoted.scope-segment.scope-selector -->
 <!--                                       ^ punctuation.separator.scope-segments.scope-selector -->
 <!--                                        ^^^^^^^ string.unquoted.scope-segment.scope-selector -->
@@ -247,7 +247,29 @@
 <!--                                                ^^^^^ string.unquoted.scope-segment.scope-selector -->
 <!--                                                     ^ punctuation.separator.scope-segments.scope-selector -->
 <!--                                                      ^^^^^ string.unquoted.scope-segment.scope-selector -->
-<!--                                                           ^^^^^^^^^ meta.tag.xml - meta.inside-value -->
+<!--                                                            ^^^^^ constant.character.entity.xml keyword.operator.with.scope-selector -->
+<!--                                                                  ^ punctuation.section.group.begin.scope-selector -->
+<!--                                                                           ^ invalid.illegal.missing-group-end.scope-selector -->
+<!--                                                                            ^^^^^^^^^ meta.tag.xml - meta.inside-value -->
+                        <key>end</key>
+                        <string>( ( meta.group | meta.brackets ) &amp; string ) &amp; punctuation <!-- comment --> noscope </string>
+<!--                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-dict.foldScopes.tmPreferences -->
+<!--                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist meta.string.selector.tmPreferences -->
+<!--                                                                                              ^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist invalid.deprecated.ignored-after-comment-or-cdata.tmPreferences -->
+<!--                                                                                                                      ^ meta.inside-value.string.plist - illegal -->
+<!--                            ^^ meta.group.scope-selector - meta.group meta.group -->
+<!--                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.scope-selector meta.group.scope-selector -->
+<!--                                                            ^^^^^^^^^^^^^^^ meta.group.scope-selector - meta.group meta.group -->
+<!--                            ^ punctuation.section.group.begin.scope-selector -->
+<!--                              ^ punctuation.section.group.begin.scope-selector -->
+<!--                                           ^ keyword.operator.or.scope-selector -->
+<!--                                                           ^ punctuation.section.group.end.scope-selector -->
+<!--                                                             ^^^^^ constant.character.entity.xml keyword.operator.with.scope-selector -->
+<!--                                                                   ^^^^^^ string.unquoted.scope-segment.scope-selector -->
+<!--                                                                          ^ punctuation.section.group.end.scope-selector -->
+<!--                                                                            ^^^^^ constant.character.entity.xml keyword.operator.with.scope-selector -->
+<!--                                                                                  ^^^^^^^^^^^ string.unquoted.scope-segment.scope-selector -->
+<!--                                                                                              ^^^^^^^^^^^^^^^^ comment.block.xml -->
                 </dict>
 <!--            ^^^^^^^ meta.inside-array.foldScopes.tmPreferences meta.tag.xml - invalid -->
             </array>

--- a/Package/TextMate Preferences/syntax_test_tmPreferences.xml
+++ b/Package/TextMate Preferences/syntax_test_tmPreferences.xml
@@ -146,16 +146,16 @@
 <!--              ^ - invalid -->
                 <string></string>
 <!--             ^^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
-<!--                     ^^^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+<!--                      ^^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
                 <dict>
                     <string>fg</string>
 <!--                 ^^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
 <!--                        ^^ invalid.illegal.unexpected-text.plist -->
-<!--                           ^^^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+<!--                            ^^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
                     <test>fg</test>
 <!--                 ^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
 <!--                      ^^ invalid.illegal.unexpected-text.plist -->
-<!--                         ^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+<!--                          ^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
                     <key>example</key>
 <!--                     ^^^^^^^ meta.inside-dict-key.plist - entity -->
                     <string>&amp;</string>

--- a/Package/TextMate Preferences/syntax_test_tmPreferences.xml
+++ b/Package/TextMate Preferences/syntax_test_tmPreferences.xml
@@ -91,13 +91,13 @@
 <!--               ^ meta.shellVariable.key.tmPreferences meta.inside-dict-key.plist - meta.tag -->
 <!--                ^^^^^^ meta.shellVariable.key.tmPreferences meta.tag.xml -->
                     <string>
-<!--                ^^^^^^^^ meta.shellVariable-name.wrapper.tmPreferences meta.tag.xml - meta.inside-value.string -->
-<!--                        ^ meta.shellVariable-name.wrapper.tmPreferences meta.inside-value.string.plist - meta.tag -->
+<!--                ^^^^^^^^ meta.shellVariable.name.tmPreferences meta.tag.xml - meta.inside-value.string -->
+<!--                        ^ meta.shellVariable.name.tmPreferences meta.inside-value.string.plist - meta.tag -->
                         TM_COMMENT_START
-<!--                    ^^^^^^^^^^^^^^^^ meta.shellVariable-name.wrapper.tmPreferences meta.inside-value.string.plist support.constant.shellVariable.tmPreferences - meta.tag -->
+<!--                    ^^^^^^^^^^^^^^^^ meta.shellVariable.name.tmPreferences meta.inside-value.string.plist support.constant.shellVariable.tmPreferences - meta.tag -->
                     </string>
-<!--               ^ meta.shellVariable-name.wrapper.tmPreferences meta.inside-value.string.plist - meta.tag -->
-<!--                ^^^^^^^^^ meta.shellVariable-name.wrapper.tmPreferences meta.tag.xml - meta.inside-value.string -->
+<!--               ^ meta.shellVariable.name.tmPreferences meta.inside-value.string.plist - meta.tag -->
+<!--                ^^^^^^^^^ meta.shellVariable.name.tmPreferences meta.tag.xml - meta.inside-value.string -->
                     <key>value</key>
                     <string>TEST </string>
                 </dict>

--- a/Package/TextMate Preferences/syntax_test_tmPreferences.xml
+++ b/Package/TextMate Preferences/syntax_test_tmPreferences.xml
@@ -183,11 +183,11 @@
 <!--             ^^^^^^^^^^ meta.inside-dict-key.plist keyword.other.foldScopes.tmPreferences -->
             <array>
                 <dict>
-                        <key>begin<
+                        <key>begin</
 <!--                    ^^^^^^^^^^^^ meta.inside-dict.foldScopes.tmPreferences -->
 <!--                     ^^^ entity.name.tag.localname.xml -->
 <!--                         ^^^^^ meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences -->
-<!--                              ^ punctuation.definition.tag.begin.xml -->
+<!--                              ^^ invalid - meta.tag - punctuation.definition.tag -->
                 </dict>
 <!--            ^^^^^^^ meta.inside-array.foldScopes.tmPreferences meta.tag.xml - invalid -->
             </array>

--- a/Package/TextMate Preferences/syntax_test_tmPreferences.xml
+++ b/Package/TextMate Preferences/syntax_test_tmPreferences.xml
@@ -5,12 +5,27 @@
 <!--                ^^^^^ string.quoted.double.xml -->
      <dict>
         <key>name</key>
-<!-- <- meta.inside-plist.plist meta.inside-dict.plist -->
-<!--    ^^^^^ meta.tag.xml -->
-<!--         ^^^^ meta.inside-dict-key.plist keyword.other.name.tmPreferences-->
-<!--             ^^^^^^ meta.tag.xml -->
+<!--   ^^^^^^^^^^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences -->
+<!--   ^ - meta.main-key-wrapper - meta.tag -->
+<!--    ^^^^^ meta.main-key-wrapper.tmPreferences meta.tag.xml -->
+<!--         ^^^^ meta.main-key-wrapper.tmPreferences meta.inside-dict-key.plist keyword.other.name.tmPreferences -->
+<!--             ^^^^^^ meta.main-key-wrapper.tmPreferences meta.tag.xml -->
+<!--                   ^ - meta.main-key-wrapper - meta.tag -->
         <string>useless name that ST ignores</string>
-<!--    ^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist -->
+<!--    ^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences -->
+
+        <key>
+<!--    ^^^^^ meta.main-key-wrapper.tmPreferences meta.tag.xml - meta.inside-dict-key -->
+<!--         ^ meta.main-key-wrapper.tmPreferences meta.inside-dict-key.plist - meta.tag -->
+                name
+<!--            ^^^^ meta.main-key-wrapper.tmPreferences meta.inside-dict-key.plist keyword.other.name.tmPreferences -->
+        </key>
+<!--   ^ meta.main-key-wrapper.tmPreferences meta.inside-dict-key.plist - meta.tag -->
+<!--    ^^^^^^ meta.main-key-wrapper.tmPreferences meta.tag.xml - meta.inside-dict-key -->
+<!--          ^ - meta.main-key-wrapper - meta.tag -->
+
+        <string>useless name that ST ignores</string>
+<!--    ^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences -->
 
         <key>scope</key>
 <!--    ^^^^^ meta.tag.xml -->
@@ -19,20 +34,30 @@
 <!--              ^^ punctuation.definition.tag.begin.xml -->
 <!--                ^^^ entity.name.tag.localname.xml -->
         <string>source.test</string>
-<!--    ^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml punctuation.definition.tag.begin.xml -->
-<!--     ^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml entity.name.tag.localname.xml -->
-<!--           ^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml punctuation.definition.tag.end.xml -->
-<!--            ^^^^^^^^^^ meta.inside-value.string.plist meta.toc-list.scope.tmPreferences -->
+<!--   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences -->
+<!--    ^ meta.tag.xml punctuation.definition.tag.begin.xml - entity -->
+<!--     ^^^^^^ meta.tag.xml entity.name.tag.localname.xml - punctuation -->
+<!--           ^ meta.tag.xml punctuation.definition.tag.end.xml - entity -->
+<!--            ^^^^^^^^^^^ meta.inside-value.string.plist meta.string.selector.tmPreferences -->
 <!--            ^^^^^^ string.unquoted.scope-segment.scope-selector -->
-<!--                         ^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml entity.name.tag.localname.xml -->
+<!--                  ^ punctuation.separator.scope-segments.scope-selector -->
+<!--                   ^^^^ string.unquoted.scope-segment.scope-selector -->
+<!--                       ^^ meta.tag.xml punctuation.definition.tag.begin.xml - entity -->
+<!--                         ^^^^^^ meta.tag.xml entity.name.tag.localname.xml - punctuation -->
+<!--                               ^ meta.tag.xml punctuation.definition.tag.end.xml - entity -->
         <key>scope</key><!-- comment -->
-<!--                    ^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist comment.block.xml -->
+<!--                    ^^^^^^^^^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences comment.block.xml -->
         <string><![CDATA[abc & (def - ghi & jkl)]]></string>
-<!--            ^^^^^^^^^ string.unquoted.cdata.xml punctuation.definition.string.begin.xml -->
-<!--                                            ^^^ string.unquoted.cdata.xml punctuation.definition.string.end.xml -->
-<!--                     ^^^^^^^^^^^^^^^^^^^^^^^ meta.toc-list.scope.tmPreferences -->
+<!--            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist meta.tag.sgml.cdata.xml -->
+<!--            ^^^ punctuation.definition.tag.begin.xml -->
+<!--               ^^^^^ keyword.declaration.cdata.xml -->
+<!--                    ^ punctuation.definition.tag.begin.xml -->
+<!--                     ^^^^^^^^^^^^^^^^^^^^^^^ meta.string.selector.tmPreferences -->
+<!--                                            ^^^ punctuation.definition.tag.end.xml - meta.string - invalid -->
 <!--                         ^ keyword.operator.with.scope-selector -->
+<!--                           ^ punctuation.section.group.begin.scope-selector -->
 <!--                                      ^ keyword.operator.with.scope-selector -->
+<!--                                           ^ punctuation.section.group.end.scope-selector -->
         <key>scope</key>
         <string>abc & (def - ghi & jkl &amp; mno)</string>
 <!--                ^ invalid.illegal.bad-ampersand.xml -->
@@ -42,24 +67,45 @@
         <key>settings</key>
 <!--         ^^^^^^^^ meta.inside-dict-key.plist keyword.other.settings.tmPreferences-->
         <dict>
-<!--          ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict.settings.tmPreferences -->
-            <key>shellVariables</key>
-<!--             ^^^^^^^^^^^^^^ meta.inside-dict-key.plist keyword.other.shellVariables.tmPreferences -->
+<!--          ^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict.settings.tmPreferences -->
+            <key>
+<!--       ^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict.settings.tmPreferences -->
+<!--        ^^^^^ meta.settings-key-wrapper.tmPreferences meta.tag.xml - meta.inside-dict-key -->
+<!--             ^ meta.settings-key-wrapper.tmPreferences meta.inside-dict-key.plist - meta.tag -->
+                shellVariables
+<!--            ^^^^^^^^^^^^^^ meta.settings-key-wrapper.tmPreferences meta.inside-dict-key.plist keyword.other.shellVariables.tmPreferences -->
+            </key>
+<!--       ^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict.settings.tmPreferences -->
+<!--       ^ meta.settings-key-wrapper.tmPreferences meta.inside-dict-key.plist - meta.tag -->
+<!--        ^^^^^ meta.settings-key-wrapper.tmPreferences meta.tag.xml - meta.inside-dict-key -->
             <array>
-<!--               ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict.settings.tmPreferences meta.inside-array.plist -->
+<!--               ^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict.settings.tmPreferences meta.inside-array.shellVariables.tmPreferences -->
                 <dict>
-<!--                  ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict.settings.tmPreferences meta.inside-array.plist meta.inside-dict.shellVariables -->
-                    <key>name</key>
-                    <string>TM_COMMENT_START</string>
-<!--                        ^^^^^^^^^^^^^^^^ meta.inside-value.string.plist entity.name.constant.shellVariable.tmPreferences support.type.shellVariable.tmPreferences -->
+<!--                  ^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict.settings.tmPreferences meta.inside-array.shellVariables.tmPreferences meta.inside-dict.shellVariables -->
+                    <key>
+<!--                ^^^^^ meta.shellVariable-key-wrapper.tmPreferences meta.tag.xml -->
+<!--                     ^ meta.shellVariable-key-wrapper.tmPreferences meta.inside-dict-key.plist - meta.tag -->
+                        name
+<!--                    ^^^^ meta.shellVariable-key-wrapper.tmPreferences meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences -->
+                    </key>
+<!--               ^ meta.shellVariable-key-wrapper.tmPreferences meta.inside-dict-key.plist - meta.tag -->
+<!--                ^^^^^^ meta.shellVariable-key-wrapper.tmPreferences meta.tag.xml -->
+                    <string>
+<!--                ^^^^^^^^ meta.shellVariable-name.wrapper.tmPreferences meta.tag.xml - meta.inside-value.string -->
+<!--                        ^ meta.shellVariable-name.wrapper.tmPreferences meta.inside-value.string.plist - meta.tag -->
+                        TM_COMMENT_START
+<!--                    ^^^^^^^^^^^^^^^^ meta.shellVariable-name.wrapper.tmPreferences meta.inside-value.string.plist support.constant.shellVariable.tmPreferences - meta.tag -->
+                    </string>
+<!--               ^ meta.shellVariable-name.wrapper.tmPreferences meta.inside-value.string.plist - meta.tag -->
+<!--                ^^^^^^^^^ meta.shellVariable-name.wrapper.tmPreferences meta.tag.xml - meta.inside-value.string -->
                     <key>value</key>
                     <string>TEST </string>
                 </dict>
                 <dict>
-<!--                  ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict.settings.tmPreferences meta.inside-array.plist meta.inside-dict.shellVariables -->
+<!--                  ^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict.settings.tmPreferences meta.inside-array.shellVariables.tmPreferences meta.inside-dict.shellVariables -->
                     <key>name</key>
                     <string>TM_COMMENT_START_2</string>
-<!--                        ^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist entity.name.constant.shellVariable.tmPreferences support.type.shellVariable.tmPreferences -->
+<!--                        ^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist support.constant.shellVariable.tmPreferences -->
                     <key>value</key>
                     <string>  <!-- test --># blah<!-- foo -->ignored by ST<gfg/>h</string>
 <!--                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist -->
@@ -72,7 +118,7 @@
 <!--                                                                             ^^^^^^^^^ meta.tag.xml -->
                 </dict>
                 <dict>
-<!--                  ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict.settings.tmPreferences meta.inside-array.plist meta.inside-dict.shellVariables -->
+<!--                  ^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict.settings.tmPreferences meta.inside-array.shellVariables.tmPreferences meta.inside-dict.shellVariables -->
                     <key>name</key>
                     <string>TM_COMMENT_START_</string>
 <!--                        ^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist entity.name.constant.shellVariable.tmPreferences - support -->
@@ -80,15 +126,15 @@
                     <string># blah </string>
                 </dict>
                 <dict>
-<!--                  ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict.settings.tmPreferences meta.inside-array.plist meta.inside-dict.shellVariables -->
+<!--                  ^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict.settings.tmPreferences meta.inside-array.shellVariables.tmPreferences meta.inside-dict.shellVariables -->
                     <key>name</key>
                     <string>TM_COMMENT_DISABLE_INDENT_2</string>
-<!--                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist entity.name.constant.shellVariable.tmPreferences support.type.shellVariable.tmPreferences -->
+<!--                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist support.constant.shellVariable.tmPreferences -->
                     <key>value</key>
                     <string>yes</string>
                 </dict>
                 <dict>
-<!--                  ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict.settings.tmPreferences meta.inside-array.plist meta.inside-dict.shellVariables -->
+<!--                  ^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict.settings.tmPreferences meta.inside-array.shellVariables.tmPreferences meta.inside-dict.shellVariables -->
                     <key>name</key>
                     <string>test</string>
 <!--                        ^^^^ meta.inside-value.string.plist entity.name.constant.shellVariable.tmPreferences - support -->
@@ -99,14 +145,19 @@
 <!--            ^^ invalid.illegal.unexpected-text.plist -->
 <!--              ^ - invalid -->
                 <string></string>
-<!--             ^^^^^^ invalid -->
+<!--             ^^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+<!--                     ^^^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
                 <dict>
                     <string>fg</string>
 <!--                 ^^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+<!--                        ^^ invalid.illegal.unexpected-text.plist -->
+<!--                           ^^^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
                     <test>fg</test>
 <!--                 ^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
+<!--                      ^^ invalid.illegal.unexpected-text.plist -->
+<!--                         ^^^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
                     <key>example</key>
-<!--                     ^^^^^^^ invalid.deprecated.expected-name-or-value.tmPreferences -->
+<!--                     ^^^^^^^ meta.inside-dict-key.plist - entity -->
                     <string>&amp;</string>
 <!--                 ^^^^^^ - invalid -->
 <!--                        ^^^^^ constant.character.entity.named.xml -->
@@ -134,11 +185,11 @@
                 <dict>
                         <key>begin<
 <!--                    ^^^^^^^^^^^^ meta.inside-dict.foldScopes.tmPreferences -->
-<!--                     ^^^ invalid.illegal.unknown-or-unexpected-tag.plist -->
-<!--                         ^^^^^ invalid.illegal.unexpected-text.plist -->
+<!--                     ^^^ entity.name.tag.localname.xml -->
+<!--                         ^^^^^ meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences -->
 <!--                              ^ punctuation.definition.tag.begin.xml -->
                 </dict>
-<!--            ^^^^^^^ meta.inside-array.plist meta.tag.xml - invalid -->
+<!--            ^^^^^^^ meta.inside-array.foldScopes.tmPreferences meta.tag.xml - invalid -->
             </array>
 <!--        ^^^^^^^^ meta.inside-dict.settings.tmPreferences meta.tag.xml - invalid -->
 
@@ -149,11 +200,11 @@
 <!--                    ^^^^^^^^^^^^^^^^ meta.inside-dict.foldScopes.tmPreferences -->
 <!--                    ^^^^^ meta.tag.xml - meta.inside-dict-key -->
 <!--                     ^^^ entity.name.tag.localname.xml -->
-<!--                         ^^^^^ meta.inside-dict-key.plist -->
+<!--                         ^^^^^ meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences -->
 <!--                              ^^^^^^ meta.tag.xml - meta.inside-dict-key -->
 <!--                                ^^^ entity.name.tag.localname.xml -->
                 </dict>
-<!--            ^^^^^^^ meta.inside-array.plist meta.tag.xml - invalid -->
+<!--            ^^^^^^^ meta.inside-array.foldScopes.tmPreferences meta.tag.xml - invalid -->
             </array>
 <!--        ^^^^^^^^ meta.inside-dict.settings.tmPreferences meta.tag.xml - invalid -->
 
@@ -164,14 +215,14 @@
 <!--                    ^^^^^^^^^^^^^^^^ meta.inside-dict.foldScopes.tmPreferences -->
 <!--                    ^^^^^ meta.tag.xml - meta.inside-dict-key -->
 <!--                     ^^^ entity.name.tag.localname.xml -->
-<!--                         ^^^^^ meta.inside-dict-key.plist -->
+<!--                         ^^^^^ meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences -->
 <!--                              ^^^^^^ meta.tag.xml - meta.inside-dict-key -->
 <!--                                ^^^ entity.name.tag.localname.xml -->
                         <string>
-<!--                    ^^^^^^^^ meta.scope-name.tmPreferences meta.tag.xml -->
+<!--                    ^^^^^^^^ meta.tag.xml -->
                 </dict>
-<!--           ^ invalid.illegal.missing-tag-end.xml -->
-<!--            ^^^^^^^ meta.inside-array.plist meta.tag.xml - invalid -->
+<!--           ^ invalid.illegal.missing-tag.plist -->
+<!--            ^^^^^^^ meta.inside-array.foldScopes.tmPreferences meta.tag.xml - invalid -->
             </array>
 <!--        ^^^^^^^^ meta.inside-dict.settings.tmPreferences meta.tag.xml - invalid -->
 
@@ -182,12 +233,13 @@
 <!--                    ^^^^^^^^^^^^^^^^ meta.inside-dict.foldScopes.tmPreferences -->
 <!--                    ^^^^^ meta.tag.xml - meta.inside-dict-key -->
 <!--                     ^^^ entity.name.tag.localname.xml -->
-<!--                         ^^^^^ meta.inside-dict-key.plist -->
+<!--                         ^^^^^ meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences -->
 <!--                              ^^^^^^ meta.tag.xml - meta.inside-dict-key -->
 <!--                                ^^^ entity.name.tag.localname.xml -->
                         <string>punctuation.section.group.begin</string>
-<!--                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-dict.foldScopes.tmPreferences meta.scope-name.tmPreferences -->
-<!--                    ^^^^^^^^ meta.tag.xml -->
+<!--                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-dict.foldScopes.tmPreferences -->
+<!--                    ^^^^^^^^ meta.tag.xml - meta.inside-value -->
+<!--                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist -->
 <!--                            ^^^^^^^^^^^ string.unquoted.scope-segment.scope-selector -->
 <!--                                       ^ punctuation.separator.scope-segments.scope-selector -->
 <!--                                        ^^^^^^^ string.unquoted.scope-segment.scope-selector -->
@@ -195,9 +247,9 @@
 <!--                                                ^^^^^ string.unquoted.scope-segment.scope-selector -->
 <!--                                                     ^ punctuation.separator.scope-segments.scope-selector -->
 <!--                                                      ^^^^^ string.unquoted.scope-segment.scope-selector -->
-<!--                                                           ^^^^^^^^^ meta.tag.xml -->
+<!--                                                           ^^^^^^^^^ meta.tag.xml - meta.inside-value -->
                 </dict>
-<!--            ^^^^^^^ meta.inside-array.plist meta.tag.xml - invalid -->
+<!--            ^^^^^^^ meta.inside-array.foldScopes.tmPreferences meta.tag.xml - invalid -->
             </array>
 <!--        ^^^^^^^^ meta.inside-dict.settings.tmPreferences meta.tag.xml - invalid -->
 
@@ -206,52 +258,55 @@
             <false />
 <!--         ^^^^^ entity.name.tag.localname.xml constant.language.boolean.plist -->
             <key>decreaseIndentPattern</key>
-<!--             ^^^^^^^^^^^^^^^^^^^^^ meta.inside-dict-key.plist entity.name.constant.setting.regex.tmPreferences -->
+<!--             ^^^^^^^^^^^^^^^^^^^^^ meta.inside-dict-key.plist entity.name.constant.setting.regexp.tmPreferences -->
             <string>^\s*(?i:end|else|elseif|loop|wend|next)(\s|$)</string>
-<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-value.string.plist meta.regex.tmPreferences -->
+<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-value.string.plist meta.string.regexp.tmPreferences -->
 <!--                ^ keyword.control.anchors.regexp -->
 <!--                                                               ^^^^^^ meta.tag.xml entity.name.tag.localname.xml -->
             <key>increaseIndentPattern</key>
-<!--             ^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist entity.name.constant.setting.regex.tmPreferences -->
+<!--             ^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict-key.plist entity.name.constant.setting.regexp.tmPreferences -->
             <string>example containing <bad & characters. (?<=doh)</string>
 <!--                                   ^ invalid.illegal.missing-entity.xml -->
 <!--                                        ^ invalid.illegal.bad-ampersand.xml -->
 <!--                                                    ^ keyword.other.any.regexp -->
 <!--                                                        ^ invalid.illegal.missing-entity.xml -->
             <key>increaseIndentPattern</key>
-<!--             ^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist entity.name.constant.setting.regex.tmPreferences -->
+<!--             ^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict-key.plist entity.name.constant.setting.regexp.tmPreferences -->
             <string><![CDATA[example containing <bad> & characters. (?<=doh)\k<test+0>]]></string>
-<!--                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-value.string.plist meta.regex.tmPreferences - invalid -->
-<!--                ^^^^^^^^^ string.unquoted.cdata.xml punctuation.definition.string.begin.xml - meta.regex.tmPreferences -->
-<!--                                                                                  ^^^ string.unquoted.cdata.xml punctuation.definition.string.end.xml - meta.regex.tmPreferences -->
+<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict.settings.tmPreferences meta.inside-value.string.plist meta.tag.sgml.cdata.xml -->
+<!--                ^^^ punctuation.definition.tag.begin.xml -->
+<!--                   ^^^^^ keyword.declaration.cdata.xml - meta.string -->
+<!--                        ^ punctuation.definition.tag.begin.xml - meta.string -->
+<!--                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.regexp.tmPreferences source.regexp - invalid -->
 <!--                                                                 ^^^ constant.other.assertion.regexp -->
 <!--                                                                        ^^^^^^^^^^ keyword.other.backref-and-recursion.regexp -->
 <!--                                                                               ^^ constant.numeric.backref-level.regexp -->
+<!--                                                                                  ^^^ punctuation.definition.tag.end.xml - meta.string - invalid -->
             <key>bracketIndentNextLinePattern</key>
             <string><![CDATA[(?x)
                 (?=wow) # this is a comment
 <!--             ^^ constant.other.assertion.regexp -->
-<!--                    ^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-value.string.plist meta.regex.tmPreferences comment.line.number-sign.regexp -->
+<!--                    ^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-value.string.plist meta.string.regexp.tmPreferences comment.line.number-sign.regexp -->
             ]]></string>
-<!--        ^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-value.string.plist string.unquoted.cdata.xml punctuation.definition.string.end.xml -->
+<!--        ^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-value.string.plist meta.tag.sgml.cdata.xml punctuation.definition.tag.end.xml - meta.string - invalid -->
 <!--             ^^^^^^ meta.tag.xml entity.name.tag.localname.xml -->
             <key>disableIndentNextLinePattern</key><string></string>
-<!--             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist entity.name.constant.setting.regex.tmPreferences -->
-<!--                                                         ^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml entity.name.tag.localname.xml -->
+<!--             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict-key.plist entity.name.constant.setting.regexp.tmPreferences -->
+<!--                                                         ^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.tag.xml entity.name.tag.localname.xml -->
             <key>indentNextLinePattern</key>
-<!--             ^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist - entity.name -->
-<!--                                  ^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml meta.close-unknown-dict-key-tag.tmPreferences punctuation.definition.tag.begin.xml -->
+<!--             ^^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict-key.plist - entity.name -->
+<!--                                  ^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.tag.xml punctuation.definition.tag.begin.xml -->
             <string>not a real key</string>
-<!--                ^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-value.string.plist - meta.regex.tmPreferences -->
+<!--                ^^^^^^^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-value.string.plist - meta.string.regexp.tmPreferences -->
             <key></key>
-<!--             ^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml meta.close-unknown-dict-key-tag.tmPreferences punctuation.definition.tag.begin.xml -->
+<!--             ^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.tag.xml punctuation.definition.tag.begin.xml -->
             <string>not a real key</string>
-<!--                ^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-value.string.plist - meta.regex.tmPreferences -->
+<!--                ^^^^^^^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-value.string.plist - meta.string.regexp.tmPreferences -->
 
             <key>cancelCompletion</key>
-<!--             ^^^^^^^^^^^^^^^^ entity.name.constant.setting.regex.tmPreferences -->
+<!--             ^^^^^^^^^^^^^^^^ entity.name.constant.setting.regexp.tmPreferences -->
             <string> <!-- test -->.*<!-- comment -->ignored by ST<![CDATA[test</string>]]>dfdf</string>
-<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist -->
+<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist -->
 <!--                 ^^^^^^^^^^^^^ comment.block.xml -->
 <!--                              ^^ keyword - invalid - comment -->
 <!--                                ^^^^^^^^^^^^^^^^ comment.block.xml -->
@@ -259,35 +314,35 @@
 <!--                                                                                          ^^^^^^^^^ meta.tag.xml -->
             <key>cancelCompletion</key>
             <string> <![CDATA[.*]]>ignored by ST<![CDATA[<!-- test --> </string>]]>test<!-- still ignored -->here   </string>
-<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist -->
+<!--                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist -->
 <!--                ^ - comment - invalid - string -->
-<!--                 ^^^^^^^^^ string.unquoted.cdata.xml -->
-<!--                            ^^^ string.unquoted.cdata.xml -->
+<!--                 ^^^^^^^^^^^^^^ meta.tag.sgml.cdata.xml -->
 <!--                          ^^ keyword -->
 <!--                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid.deprecated.ignored-after-comment-or-cdata -->
 <!--                               ^^^^^^^^^^^^^ - string - keyword - comment -->
+<!--                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.xml -->
 <!--                                                                                   ^^^^^^^^^^^^^^^^^^^^^^ comment.block.xml -->
 <!--                                                                                                         ^^^^ invalid.deprecated.ignored-after-comment-or-cdata -->
 <!--                                                                                                             ^^^ - invalid -->
 <!--                                                                                                                ^^^^^^^^^ meta.tag.xml -->
 
             <key>showInSymbolList</key>
-<!--             ^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences -->
+<!--             ^^^^^^^^^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences -->
             <integer>1</integer>text
-<!--                 ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-value.integer.plist constant.numeric.plist -->
-<!--                            ^^^^ meta.inside-plist.plist meta.inside-dict.plist invalid.illegal.unexpected-text.plist -->
+<!--                 ^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-value.integer.plist constant.numeric.plist -->
+<!--                            ^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences invalid.illegal.unexpected-text.plist -->
             <key>showInIndexedSymbolList</key>
-<!--             ^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences -->
+<!--             ^^^^^^^^^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences -->
             text<string>0</string>
-<!--        ^^^^ meta.inside-plist.plist meta.inside-dict.plist invalid.illegal.unexpected-text.plist -->
-<!--             ^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.tag.xml entity.name.tag.localname.xml -->
-<!--                    ^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist constant.numeric.tmPreferences -->
+<!--        ^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences invalid.illegal.unexpected-text.plist -->
+<!--             ^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.tag.xml entity.name.tag.localname.xml -->
+<!--                    ^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-value.string.plist constant.numeric.tmPreferences -->
             <key>symbolTransformation</key>
-<!--             ^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-dict-key.plist entity.name.constant.setting.regex-transform.tmPreferences -->
+<!--             ^^^^^^^^^^^^^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict-key.plist entity.name.constant.setting.regexp-transform.tmPreferences -->
             <string><![CDATA[
                 s/(\[[^\]]*\])|\b_\b\s*|\(.*|(\s{2,})/$1(?2 )/g; (?# this is a regex transformation
-<!--              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.regex.transformation.tmPreferences source.regexp.oniguruma -->
-<!--            ^^ meta.inside-plist.plist meta.inside-dict.plist meta.inside-value.string.plist meta.regex.transformation.tmPreferences punctuation.definition.substitute-what.tmPreferences -->
+<!--              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.regexp.transformation.tmPreferences source.regexp.oniguruma -->
+<!--            ^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-value.string.plist meta.string.regexp.transformation.tmPreferences punctuation.definition.substitute-what.tmPreferences -->
 <!--                                                 ^ punctuation.definition.substitute-with.tmPreferences - source -->
 <!--                                                     ^^ keyword.other.backref-and-recursion.conditional.regexp-replacement -->
 <!--                                                         ^ punctuation.definition.substitute-flags.tmPreferences -->
@@ -299,14 +354,18 @@
 <!--             ^ keyword.other.any.regexp -->
             note that we don't end the comment, but the CDATA end still applies
             ]]></string>
-<!--        ^^^ string.unquoted.cdata.xml punctuation.definition.string.end.xml -->
+<!--        ^^^ meta.tag.sgml.cdata.xml punctuation.definition.tag.end.xml - meta.string - invalid -->
         </dict>
 
     </dict>
-<!--  ^^^^ meta.inside-plist.plist meta.tag.xml entity.name.tag.localname.xml - invalid -->
+<!--  ^^^^ meta.inside-plist.tmPreferences meta.tag.xml entity.name.tag.localname.xml - invalid -->
 </plist>
-<!-- ^^ meta.inside-plist.plist meta.tag.xml entity.name.tag.localname.xml - invalid -->
+<!-- ^^ meta.tag.xml entity.name.tag.localname.xml - invalid -->
 test
 <!-- <- invalid.illegal.unexpected-text.plist -->
 <!-- comment -->
 <!-- <- comment.block.xml punctuation.definition.comment.begin.xml -->
+<plist>
+<!-- <- meta.tag.xml punctuation.definition.tag.begin.xml -->
+<!-- ^^ meta.tag.xml -->
+<!-- ^ invalid.illegal.unknown-or-unexpected-tag.plist -->

--- a/Package/TextMate Preferences/syntax_test_tmPreferences.xml
+++ b/Package/TextMate Preferences/syntax_test_tmPreferences.xml
@@ -6,23 +6,23 @@
      <dict>
         <key>name</key>
 <!--   ^^^^^^^^^^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences -->
-<!--   ^ - meta.main-key-wrapper - meta.tag -->
-<!--    ^^^^^ meta.main-key-wrapper.tmPreferences meta.tag.xml -->
-<!--         ^^^^ meta.main-key-wrapper.tmPreferences meta.inside-dict-key.plist keyword.other.name.tmPreferences -->
-<!--             ^^^^^^ meta.main-key-wrapper.tmPreferences meta.tag.xml -->
-<!--                   ^ - meta.main-key-wrapper - meta.tag -->
+<!--   ^ - meta.main.key - meta.tag -->
+<!--    ^^^^^ meta.main.key.tmPreferences meta.tag.xml -->
+<!--         ^^^^ meta.main.key.tmPreferences meta.inside-dict-key.plist keyword.other.name.tmPreferences -->
+<!--             ^^^^^^ meta.main.key.tmPreferences meta.tag.xml -->
+<!--                   ^ - meta.main.key - meta.tag -->
         <string>useless name that ST ignores</string>
 <!--    ^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences -->
 
         <key>
-<!--    ^^^^^ meta.main-key-wrapper.tmPreferences meta.tag.xml - meta.inside-dict-key -->
-<!--         ^ meta.main-key-wrapper.tmPreferences meta.inside-dict-key.plist - meta.tag -->
+<!--    ^^^^^ meta.main.key.tmPreferences meta.tag.xml - meta.inside-dict-key -->
+<!--         ^ meta.main.key.tmPreferences meta.inside-dict-key.plist - meta.tag -->
                 name
-<!--            ^^^^ meta.main-key-wrapper.tmPreferences meta.inside-dict-key.plist keyword.other.name.tmPreferences -->
+<!--            ^^^^ meta.main.key.tmPreferences meta.inside-dict-key.plist keyword.other.name.tmPreferences -->
         </key>
-<!--   ^ meta.main-key-wrapper.tmPreferences meta.inside-dict-key.plist - meta.tag -->
-<!--    ^^^^^^ meta.main-key-wrapper.tmPreferences meta.tag.xml - meta.inside-dict-key -->
-<!--          ^ - meta.main-key-wrapper - meta.tag -->
+<!--   ^ meta.main.key.tmPreferences meta.inside-dict-key.plist - meta.tag -->
+<!--    ^^^^^^ meta.main.key.tmPreferences meta.tag.xml - meta.inside-dict-key -->
+<!--          ^ - meta.main.key - meta.tag -->
 
         <string>useless name that ST ignores</string>
 <!--    ^^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences -->
@@ -70,26 +70,26 @@
 <!--          ^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict.settings.tmPreferences -->
             <key>
 <!--       ^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict.settings.tmPreferences -->
-<!--        ^^^^^ meta.settings-key-wrapper.tmPreferences meta.tag.xml - meta.inside-dict-key -->
-<!--             ^ meta.settings-key-wrapper.tmPreferences meta.inside-dict-key.plist - meta.tag -->
+<!--        ^^^^^ meta.settings.key.tmPreferences meta.tag.xml - meta.inside-dict-key -->
+<!--             ^ meta.settings.key.tmPreferences meta.inside-dict-key.plist - meta.tag -->
                 shellVariables
-<!--            ^^^^^^^^^^^^^^ meta.settings-key-wrapper.tmPreferences meta.inside-dict-key.plist keyword.other.shellVariables.tmPreferences -->
+<!--            ^^^^^^^^^^^^^^ meta.settings.key.tmPreferences meta.inside-dict-key.plist keyword.other.shellVariables.tmPreferences -->
             </key>
 <!--       ^^^^^^^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict.settings.tmPreferences -->
-<!--       ^ meta.settings-key-wrapper.tmPreferences meta.inside-dict-key.plist - meta.tag -->
-<!--        ^^^^^ meta.settings-key-wrapper.tmPreferences meta.tag.xml - meta.inside-dict-key -->
+<!--       ^ meta.settings.key.tmPreferences meta.inside-dict-key.plist - meta.tag -->
+<!--        ^^^^^ meta.settings.key.tmPreferences meta.tag.xml - meta.inside-dict-key -->
             <array>
 <!--               ^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict.settings.tmPreferences meta.inside-array.shellVariables.tmPreferences -->
                 <dict>
 <!--                  ^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict.settings.tmPreferences meta.inside-array.shellVariables.tmPreferences meta.inside-dict.shellVariables -->
                     <key>
-<!--                ^^^^^ meta.shellVariable-key-wrapper.tmPreferences meta.tag.xml -->
-<!--                     ^ meta.shellVariable-key-wrapper.tmPreferences meta.inside-dict-key.plist - meta.tag -->
+<!--                ^^^^^ meta.shellVariable.key.tmPreferences meta.tag.xml -->
+<!--                     ^ meta.shellVariable.key.tmPreferences meta.inside-dict-key.plist - meta.tag -->
                         name
-<!--                    ^^^^ meta.shellVariable-key-wrapper.tmPreferences meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences -->
+<!--                    ^^^^ meta.shellVariable.key.tmPreferences meta.inside-dict-key.plist entity.name.constant.setting.tmPreferences -->
                     </key>
-<!--               ^ meta.shellVariable-key-wrapper.tmPreferences meta.inside-dict-key.plist - meta.tag -->
-<!--                ^^^^^^ meta.shellVariable-key-wrapper.tmPreferences meta.tag.xml -->
+<!--               ^ meta.shellVariable.key.tmPreferences meta.inside-dict-key.plist - meta.tag -->
+<!--                ^^^^^^ meta.shellVariable.key.tmPreferences meta.tag.xml -->
                     <string>
 <!--                ^^^^^^^^ meta.shellVariable-name.wrapper.tmPreferences meta.tag.xml - meta.inside-value.string -->
 <!--                        ^ meta.shellVariable-name.wrapper.tmPreferences meta.inside-value.string.plist - meta.tag -->

--- a/messages.json
+++ b/messages.json
@@ -12,5 +12,6 @@
     "3.2.2": "messages/3.2.2.txt",
     "3.2.8": "messages/3.2.8.txt",
     "3.2.18": "messages/3.2.18.txt",
-    "3.3.0": "messages/3.3.0.txt"
+    "3.3.0": "messages/3.3.0.txt",
+    "3.4.0": "messages/3.4.0.txt"
 }

--- a/messages/3.4.0.txt
+++ b/messages/3.4.0.txt
@@ -1,0 +1,54 @@
+v3.4.0 (2022-03-12)
+-------------------
+
+## Minor changes
+
+- Syntax Test: New syntax test generation feature.
+  Triggered via `ctrl+enter` while on a code line in a syntax test file
+  or via the command palette. (#341 @Thom1729)
+- Syntax Test: New setting to strip previously asserted scopes from test completions
+  (#340 @Thom1729)
+- Settings: Quick edit phantoms can now be disabled (#353 @Ultra-Instinct-05)
+- Consider new system-aware color scheme switching for "Edit current Color Scheme"
+  (#330 @Ultra-Instinct-05)
+
+## Trivial changes and fixes
+
+- Syntax: Defer tab check for (semi-)transient views (#177, #365, #368, @FichteFoll)
+- Syntax: Fix syntax assignment for some test files that loaded to slowly (#358 @keith-hall)
+- Syntax: Complete `pop: 1` for syntax version 2 (#354, @FichteFoll)
+- Syntax: Fix highlighting of quoted variable keys (#356, @FichteFoll)
+- Syntax: Highlight section headers as seen in the Packages repo (#296 @deathaxe)
+- Syntax: Fix settings completions for complex values (#347, #348 @ratijas)
+- Syntax: Recognize `partial-symbols` header (#355 @keith-hall)
+- Scheme: Remove `#` from `word_separators` (#357 @MattDMo)
+- Scheme: Support missing color scheme globals (#331 @Ultra-Instinct-05)
+- Scheme: Remove `blend()` matching since it's been added to the default CSS syntax
+  (#324, @FichteFoll)
+- Theme & Scheme: Highlight `var` function for color-adjuster properties (#326 @deathaxe)
+- Theme: Support radio and checkbox controls (#362 @AmjadHD)
+- Theme: Support `close_button_side` and `connector_height` properties (#339, @FichteFoll)
+- Theme: Support color adjuster functions in variables (#327, @FichteFoll)
+- Theme: Swap `layer.draw_center` value in completion (#359 @AmjadHD)
+- Theme: `disabled` attribute (#361 @AmjadHD)
+- Theme: Update completions with color kind quick panel symbols (#323 @deathaxe)
+- Snippet: Syntax highlighting corrections for slashes in substitutions and escape sequences
+  (@FichteFoll)
+- Settings: Add hints for more default preferences (#343 @jrappen, #344 @Ultra-Instinct-05)
+- Commands: Small tweaks to command completion metadata (various)
+- Commands: Add support for the platform key (#332 @Ultra-Instinct-05)
+- Commands & Menu: Remove `invalid` highlighting for unrecognized platform names (@FichteFoll)
+- PList: associate syntax with `.hidden-*` syntaxes & native PList extensions (#325 @deathaxe)
+- Misc: Scope Name completions have been updated
+  to follow recent discussions for the default Packages (#352 @Ultra-Instinct-05, #364 @deathaxe)
+
+## Trivial changes from v3.3.1 (2021-01-23)
+
+TL;DR: Updated for 4095
+
+- Theme: Support `style` and `background_modifier` rule keys
+- Theme: Support mappings/objects for `settings` selector
+- Theme: Update list of elements and attributes to 4095
+- Scheme & Theme: Fix highlighting of `blend` color modifier function
+- Scheme & Theme: Add support for "auto" value in "edit current theme/scheme" commands
+- Settings: Offer completions for dark and light color scheme and theme variants


### PR DESCRIPTION
Fixes #377

This PR ...

1. completely refactors/rewrites _Property List_ and _TextMate Preferences_ syntax
   - switch to sublime-syntax v2
   - inherit TextMate Preferences from Property List
   - introduce a common scheme of context structure for all kinds of tags for consistent behavior
   - adds a bailout to not escalate illegal highlighting beyound array/dict boundaries.
3. adjusts completions/snippet selectors
4. fixes broken and cleans up obsolete completion/snippet selectors
5. adds some completions/snippets
6. fixes Goto Symbol for various symbols

Note: Majority of scopes is kept unchanged or tweaked only a little bit as many packages/color schemes seem to rely on them.