### PR TITLE
Add support for `TM_COMMENT_CASE_INSENSITIVE`

### DIFF
--- a/Package/TextMate Preferences/Completions/shellVariable Name.sublime-completions
+++ b/Package/TextMate Preferences/Completions/shellVariable Name.sublime-completions
@@ -2,6 +2,14 @@
     "scope": "meta.shellVariable.name.tmPreferences - (meta.tag - punctuation.definition.tag.begin.xml)",
     "completions": [
         {
+            "trigger": "TM_COMMENT_CASE_INSENSITIVE",
+            "kind": ["variable", "v", "shellVariable"],
+        },
+        {
+            "trigger": "TM_COMMENT_CASE_INSENSITIVE_2",
+            "kind": ["variable", "v", "shellVariable"],
+        },
+        {
             "trigger": "TM_COMMENT_DISABLE_INDENT",
             "kind": ["variable", "v", "shellVariable"],
         },

--- a/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
+++ b/Package/TextMate Preferences/TextMate Preferences.sublime-syntax
@@ -459,7 +459,7 @@ contexts:
     - include: string-end
     - include: value-content
     - include: comments
-    - match: \bTM_COMMENT_(?:START|END|DISABLE_INDENT)(?:_[2-9])?\b
+    - match: \bTM_COMMENT_(?:START|END|DISABLE_INDENT|CASE_INSENSITIVE)(?:_[2-9])?\b
       scope: entity.name.constant.shellVariable.tmPreferences support.constant.shellVariable.tmPreferences
       push: after-number
     - match: \b\w+\b

--- a/Package/TextMate Preferences/syntax_test_tmPreferences.xml
+++ b/Package/TextMate Preferences/syntax_test_tmPreferences.xml
@@ -136,6 +136,14 @@
                 <dict>
 <!--                  ^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict.settings.tmPreferences meta.inside-array.shellVariables.tmPreferences meta.inside-dict.shellVariables -->
                     <key>name</key>
+                    <string>TM_COMMENT_CASE_INSENSITIVE_2</string>
+<!--                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.inside-value.string.plist support.constant.shellVariable.tmPreferences -->
+                    <key>value</key>
+                    <string>yes</string>
+                </dict>
+                <dict>
+<!--                  ^ meta.inside-plist.tmPreferences meta.inside-dict.main.tmPreferences meta.inside-dict.settings.tmPreferences meta.inside-array.shellVariables.tmPreferences meta.inside-dict.shellVariables -->
+                    <key>name</key>
                     <string>test</string>
 <!--                        ^^^^ meta.inside-value.string.plist entity.name.constant.shellVariable.tmPreferences - support -->
                     <key>value</key>


### PR DESCRIPTION
Proposed in a [GitHub issue][1] and introduced in [Sublime Text 4153][2].

[1]: https://github.com/sublimehq/sublime_text/issues/6001
[2]: https://www.sublimetext.com/dev#changelog:~:text=TM_COMMENT_CASE_INSENSITIVE