### PR TITLE
[YAML-tmLanguage] Remove empty capture group from multi-line match rule

### DIFF
--- a/Package/TextMate Syntax Definition (YAML)/TextMate Syntax Definition (YAML).YAML-tmLanguage
+++ b/Package/TextMate Syntax Definition (YAML)/TextMate Syntax Definition (YAML).YAML-tmLanguage
@@ -294,7 +294,7 @@ repository:
     # multi-line (block style)
     - name: meta.match.block.yaml-tmlanguage
       contentName: meta.value.yaml-tmlanguage
-      begin: ^( *)(?:(?:-?( +)))((["']?)(match|begin|end)(\4))(:) +([|>](\d*)[-+]?)(?=, |,$| +#| *$)
+      begin: ^( *)-?( +)((["']?)(match|begin|end)(\4))(:) +([|>](\d*)[-+]?)(?=, |,$| +#| *$)
       beginCaptures:
         '3': {name: string.other.quoted-or-unquoted.yaml-tmlanguage}
         '4': {name: punctuation.definition.string.yaml-tmlanguage}

--- a/Package/TextMate Syntax Definition (YAML)/TextMate Syntax Definition (YAML).YAML-tmLanguage
+++ b/Package/TextMate Syntax Definition (YAML)/TextMate Syntax Definition (YAML).YAML-tmLanguage
@@ -294,18 +294,15 @@ repository:
     # multi-line (block style)
     - name: meta.match.block.yaml-tmlanguage
       contentName: meta.value.yaml-tmlanguage
-      # I don't have a single fucking clue why but apparently removing
-      # the empty capturing group BREAKS the regexp
-      begin: ^( *)(?:-?( +)())((["']?)(match|begin|end)(\3))(:) +([|>](\d*)[-+]?)(?=, |,$| +#| *$)
+      begin: ^( *)(?:(?:-?( +)))((["']?)(match|begin|end)(\4))(:) +([|>](\d*)[-+]?)(?=, |,$| +#| *$)
       beginCaptures:
-        '4': {name: string.other.quoted-or-unquoted.yaml-tmlanguage}
-        '5': {name: punctuation.definition.string.yaml-tmlanguage}
-        '6': {name: keyword.other.match.yaml-tmlanguage}
-        '7': {name: punctuation.definition.string.yaml-tmlanguage}
-        '8': {name: keyword.control.definition.yaml-tmlanguage}
-
-        '9': {name: keyword.control.block.yaml-tmlanguage}
-        '10': {name: constant.numeric.indentation-indicator.yaml-tmlanguage}
+        '3': {name: string.other.quoted-or-unquoted.yaml-tmlanguage}
+        '4': {name: punctuation.definition.string.yaml-tmlanguage}
+        '5': {name: keyword.other.match.yaml-tmlanguage}
+        '6': {name: punctuation.definition.string.yaml-tmlanguage}
+        '7': {name: keyword.control.definition.yaml-tmlanguage}
+        '8': {name: keyword.control.block.yaml-tmlanguage}
+        '9': {name: constant.numeric.indentation-indicator.yaml-tmlanguage}
       # must be indented by at least as much as the key line + 1 (+ 1 for the potential '-')
       end: ^(?! *$|\1\2  )
       patterns:

--- a/Package/TextMate Syntax Definition (YAML)/TextMate Syntax Definition (YAML).tmLanguage
+++ b/Package/TextMate Syntax Definition (YAML)/TextMate Syntax Definition (YAML).tmLanguage
@@ -661,43 +661,43 @@ comment
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>^( *)(?:-?( +)())((["']?)(match|begin|end)(\3))(:) +([|&gt;](\d*)[-+]?)(?=, |,$| +#| *$)</string>
+					<string>^( *)(?:(?:-?( +)))((["']?)(match|begin|end)(\4))(:) +([|&gt;](\d*)[-+]?)(?=, |,$| +#| *$)</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>10</key>
-						<dict>
-							<key>name</key>
-							<string>constant.numeric.indentation-indicator.yaml-tmlanguage</string>
-						</dict>
-						<key>4</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>string.other.quoted-or-unquoted.yaml-tmlanguage</string>
 						</dict>
-						<key>5</key>
+						<key>4</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.string.yaml-tmlanguage</string>
 						</dict>
-						<key>6</key>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.other.match.yaml-tmlanguage</string>
 						</dict>
-						<key>7</key>
+						<key>6</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.string.yaml-tmlanguage</string>
 						</dict>
-						<key>8</key>
+						<key>7</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.control.definition.yaml-tmlanguage</string>
 						</dict>
-						<key>9</key>
+						<key>8</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.control.block.yaml-tmlanguage</string>
+						</dict>
+						<key>9</key>
+						<dict>
+							<key>name</key>
+							<string>constant.numeric.indentation-indicator.yaml-tmlanguage</string>
 						</dict>
 					</dict>
 					<key>contentName</key>

--- a/Package/TextMate Syntax Definition (YAML)/TextMate Syntax Definition (YAML).tmLanguage
+++ b/Package/TextMate Syntax Definition (YAML)/TextMate Syntax Definition (YAML).tmLanguage
@@ -661,7 +661,7 @@ comment
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>^( *)(?:(?:-?( +)))((["']?)(match|begin|end)(\4))(:) +([|&gt;](\d*)[-+]?)(?=, |,$| +#| *$)</string>
+					<string>^( *)-?( +)((["']?)(match|begin|end)(\4))(:) +([|&gt;](\d*)[-+]?)(?=, |,$| +#| *$)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>3</key>


### PR DESCRIPTION
Fixes the rule for matching `match`, `begin`, and `end` multi-line blocks.