### PR TITLE
Fix auto-generated syntaxes not filling gaps (#398)

### DIFF
--- a/plugins/syntaxtest_dev.py
+++ b/plugins/syntaxtest_dev.py
@@ -535,6 +535,7 @@ class ScopeTreeNode:
 
     @classmethod
     def build_forest(cls, tokens, *, trim_suffix=False):
+        print(tokens)
         tokens = [
             (region, cls._split_scope(scope, trim_suffix=trim_suffix))
             for region, scope in tokens
@@ -561,7 +562,7 @@ class ScopeTreeNode:
     def _insert(cls, forest, region, scopes):
         if scopes:
             first, *rest = scopes
-            if forest and forest[-1].scope == first:
+            if forest and forest[-1].scope == first and forest[-1].region.b == region.a:
                 forest[-1].region = forest[-1].region.cover(region)
             else:
                 forest.append(cls(region, first))


### PR DESCRIPTION
Old Version (incorrectly assumes the space has numerical scopes):
```cpp
    (123 456)
/*  ^^^^^^^^^ meta.group.c-2 */
/*  ^ punctuation.section.group.begin */
/*   ^^^^^^^ meta.number.integer.decimal.c-2 constant.numeric.value.c-2 */
/*          ^ punctuation.section.group.end */```
```
New Version (correctly excludes space from numerical scopes):
```cpp
    (123 456)
/*  ^^^^^^^^^ meta.group.c-2 */
/*  ^ punctuation.section.group.begin */
/*   ^^^ meta.number.integer.decimal.c-2 constant.numeric.value.c-2 */
/*       ^^^ meta.number.integer.decimal.c-2 constant.numeric.value.c-2 */
/*          ^ punctuation.section.group.end */
```

Simply checks if the previous region's end matches with the new region's beginning when inserting into a ScopeTreeNode.