### PR TITLE
Add support for syntax highlighting and completions of `extends` values

### DIFF
--- a/Package/PackageDev.sublime-settings
+++ b/Package/PackageDev.sublime-settings
@@ -30,6 +30,13 @@
     // settings file for this to take effect.
     "settings.show_quick_edit_icon": true,
 
+    // List of patterns for syntax not to be displayed in completions.
+    // Each theme containing one of the list's strings is hidden.
+    "settings.exclude_syntax_patterns": [
+        "*.tmLanguage",
+        "Packages/zzz A File Icon zzz/**"
+    ],
+
     // Whether or not to keep the scope suffix in the suggested test scopes
     // i.e. if the base scope is text.html.markdown
     // then suggest meta.example.markdown (true) vs meta.example (false).

--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
@@ -133,6 +133,7 @@ contexts:
       captures:
         1: string.unquoted.plain.out.yaml storage.type.extends.sublime-syntax
         2: punctuation.separator.key-value.yaml
+      push: expect_extends_list
 
     - match: ((?:hidden_)?file_extensions)\s*(:)(?=\s|$)
       captures:
@@ -161,6 +162,52 @@ contexts:
     - include: yaml-tags-anchors
 
     - include: scope:source.yaml
+
+  expect_extends_list:
+    - meta_content_scope: meta.extends.sublime-syntax
+    - include: comment
+    - include: yaml-tags-anchors
+    # array-like context list
+    - match: \[
+      scope: punctuation.definition.array.begin.sublime-syntax
+      set:
+        - meta_scope: meta.extends.sublime-syntax meta.flow-sequence.yaml
+        - match: \]
+          scope: punctuation.definition.array.end.sublime-syntax
+          pop: true
+        - match: ','
+          scope: punctuation.separator.array-element.sublime-syntax
+        - match: '{{plain_scalar_but_not_block_key}}'
+          push: extended_syntax_file
+        - include: comment
+        - include: yaml-tags-anchors
+    # multi-line context list
+    - match: ^([ ]+)(?=-\s*{{plain_scalar_but_not_block_key}})
+      set:
+        - meta_scope: meta.extends.sublime-syntax meta.block-sequence.yaml
+        # pop off at none-empty line with different indention than first item
+        - match: ^(?!(\s*$|\1-))
+          pop: true
+        - match: '{{plain_scalar_but_not_block_key}}'
+          push: extended_syntax_file
+        - include: comment
+        - include: yaml-block-sequence
+        - match: \S.*$
+          scope: invalid.illegal.extends.sublime-syntax
+    # maybe single include
+    - match: '{{plain_scalar_but_not_block_key}}'
+      set:
+        - meta_scope: meta.extends.sublime-syntax meta.path.sublime-syntax string.unquoted.plain.out.yaml
+        - include: extended_syntax_file
+    - match: ^\s*$
+      pop: 1
+
+  extended_syntax_file:
+    - meta_scope: meta.path.sublime-syntax string.unquoted.plain.out.yaml
+    - match: '{{_flow_scalar_end_plain_in}}'
+      pop: true
+    - match: /
+      scope: punctuation.separator.path.sublime-syntax
 
   variables_block:
     - meta_scope: meta.block.variables.sublime-syntax

--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
@@ -199,7 +199,7 @@ contexts:
       set:
         - meta_scope: meta.extends.sublime-syntax meta.path.sublime-syntax string.unquoted.plain.out.yaml
         - include: extended_syntax_file
-    - match: ^\s*$
+    - match: ^(?=\s*$)
       pop: 1
 
   extended_syntax_file:

--- a/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
+++ b/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
@@ -13,7 +13,26 @@ version: 2
 extends: Packages/Default/Text.sublime-syntax
 #^^^^^^ string.unquoted.plain.out.yaml storage.type.extends.sublime-syntax
 #      ^ punctuation.separator.key-value.yaml
-#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.unquoted.plain.out.yaml
+#       ^ meta.extends - meta.path
+#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.extends.sublime-syntax meta.path.sublime-syntax string.unquoted.plain.out.yaml
+#                ^ punctuation.separator.path.sublime-syntax
+#                        ^ punctuation.separator.path.sublime-syntax
+#                                            ^ - meta.extends - meta.path
+extends: [ Text.sublime-syntax , Source.sublime-syntax ]
+#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.extends.sublime-syntax meta.flow-sequence.yaml
+#         ^ - meta.path
+#          ^^^^^^^^^^^^^^^^^^^ meta.path.sublime-syntax string.unquoted.plain.out.yaml
+#                             ^^^ - meta.path
+#                                ^^^^^^^^^^^^^^^^^^^^^ meta.path.sublime-syntax string.unquoted.plain.out.yaml
+#                                                     ^^ - meta.path
+extends:
+  - Packages/Default/Text.sublime-syntax
+# <- meta.extends.sublime-syntax meta.block-sequence.yaml
+#^^^ meta.extends.sublime-syntax meta.block-sequence.yaml
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.extends.sublime-syntax meta.block-sequence.yaml meta.path.sublime-syntax string.unquoted.plain.out.yaml
+#           ^ punctuation.separator.path.sublime-syntax
+#                   ^ punctuation.separator.path.sublime-syntax
+#                                       ^ meta.extends.sublime-syntax meta.block-sequence.yaml - meta.path
 file_extensions: [a, b]
 #^^^^^^^^^^^^^^ string.unquoted.plain.out.yaml entity.name.tag.yaml
 #                ^^^^^^ meta.flow-sequence.yaml, meta.sequence.flow.yaml


### PR DESCRIPTION
This PR...

1. adds dedicated contexts/patterns to highlight `extends:` values
2. adds auto-completions for existing syntax definitions when typing within `extends:` values.