### PR TITLE
Highlight symbol tests in code lines

### DIFF
--- a/plugins/syntaxtest_dev.py
+++ b/plugins/syntaxtest_dev.py
@@ -117,7 +117,7 @@ class SyntaxTestHighlighterListener(sublime_plugin.ViewEventListener):
         test_start_token = re.match(fr'^\s*({re.escape(tokens.comment_start)})', line_text)
         assertion_colrange = None
         if test_start_token:
-            assertion = re.match(r'\s*(?:(<-)|(\^+))', line_text[test_start_token.end():])
+            assertion = re.match(r'\s*(?:(<-)|(\^+|@+))', line_text[test_start_token.end():])
             if assertion:
                 if assertion.group(1):
                     assertion_colrange = (test_start_token.start(1),


### PR DESCRIPTION
Relates to #342, specifically fixing the region highlighting:

> One thing I am excited for is for the highlighting from `^` lines to stop getting stuck on `@` lines. I've added some reference tests, and now clicking on a scope test below a reference test highlights the reference test line instead of the actual line of code to be tested.