### PR TITLE
Settings: Fix namespace highlighting

### DIFF
--- a/Package/Sublime Text Settings/Sublime Text Settings.sublime-syntax
+++ b/Package/Sublime Text Settings/Sublime Text Settings.sublime-syntax
@@ -40,7 +40,7 @@ contexts:
               scope: meta.mapping.key.json string.quoted.double.json punctuation.definition.string.end.json
               set: [expect-any-settings-value, expect-colon]
         - include: inside-string
-        - match: '[\w]+(\.)'
+        - match: '[\w]+(\.)(?![\d.]+\")'
           scope: keyword.other.namespace.sublime-settings
           captures:
             1: punctuation.separator.namespace.sublime-settings

--- a/Package/Sublime Text Settings/syntax_test_settings.json
+++ b/Package/Sublime Text Settings/syntax_test_settings.json
@@ -36,6 +36,28 @@ s
 //                     ^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.value.json
 //                       ^ - entity.name.other.key
 
+    "disable_plugin_host-3.3": true,
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key.json string.quoted.double.json
+//  ^ punctuation.definition.string.begin.json
+//   ^^^^^^^^^^^^^^^^^^^^^^^ entity.name.other.key.sublime-settings - keyword.other.namespace - punctuation.separator.namespace
+//                          ^ punctuation.definition.string.end.json
+
+    "disable_plugin-1.2.3": true,
+//  ^^^^^^^^^^^^^^^^^^^^^^ meta.mapping.key.json string.quoted.double.json
+//  ^ punctuation.definition.string.begin.json
+//   ^^^^^^^^^^^^^^^^^^^^ entity.name.other.key.sublime-settings - keyword.other.namespace - punctuation.separator.namespace
+//                       ^ punctuation.definition.string.end.json
+
+    "package.3.4.5a": true,
+//  ^^^^^^^^^^^^^^^^ meta.mapping.key.json string.quoted.double.json
+//  ^ punctuation.definition.string.begin.json
+//   ^^^^^^^^^^^^^^ entity.name.other.key.sublime-settings
+//   ^^^^^^^^^^^^ keyword.other.namespace.sublime-settings
+//          ^ punctuation.separator.namespace.sublime-settings
+//            ^ punctuation.separator.namespace.sublime-settings
+//              ^ punctuation.separator.namespace.sublime-settings
+//                 ^ punctuation.definition.string.end.json
+
     "package_name.setting": null
 //   ^^^^^^^^^^^^^^^^^^^^ entity.name.other.key.sublime-settings
 //   ^^^^^^^^^^^^^ keyword.other.namespace.sublime-settings


### PR DESCRIPTION
Resolves #406

This commit expects a setting namespace to be followed by a valid setting name, but not only numbers.