### PR TITLE
Add child combinator operator

### DIFF
--- a/Package/Scope Selector (XML).sublime-syntax
+++ b/Package/Scope Selector (XML).sublime-syntax
@@ -23,7 +23,7 @@ contexts:
   operators:
     - meta_prepend: true
     - match: (&)amp(;)
-      scope: constant.character.entity.xml keyword.operator.with.scope-selector
+      scope: constant.character.entity.xml keyword.operator.combinator.with.scope-selector
       captures:
         1: punctuation.definition.constant.xml
         2: punctuation.definition.constant.xml

--- a/Package/Scope Selector.sublime-syntax
+++ b/Package/Scope Selector.sublime-syntax
@@ -45,15 +45,17 @@ contexts:
     - match: \s+\(
       scope: invalid.illegal.operator-required-between-scope-and-group.scope-selector
     - match: \s+(?=\w)
-      scope: keyword.operator.right.scope-selector
+      scope: keyword.operator.combinator.right.scope-selector
       pop: true
     - match: ''
       pop: true
 
   operators:
+    - match: '>'
+      scope: keyword.operator.combinator.child.scope-selector
     - match: '-'
-      scope: keyword.operator.without.scope-selector
+      scope: keyword.operator.combinator.without.scope-selector
     - match: '&'
-      scope: keyword.operator.with.scope-selector
+      scope: keyword.operator.combinator.with.scope-selector
     - match: '[,|]'
-      scope: keyword.operator.or.scope-selector
+      scope: keyword.operator.combinator.or.scope-selector

--- a/Package/Scope Selector.sublime-syntax
+++ b/Package/Scope Selector.sublime-syntax
@@ -45,7 +45,7 @@ contexts:
     - match: \s+\(
       scope: invalid.illegal.operator-required-between-scope-and-group.scope-selector
     - match: \s+(?=\w)
-      scope: keyword.operator.combinator.right.scope-selector
+      scope: keyword.operator.combinator.descendent.scope-selector
       pop: true
     - match: ''
       pop: true

--- a/Package/Sublime Text Snippet/Sublime Text Snippet.sublime-syntax
+++ b/Package/Sublime Text Snippet/Sublime Text Snippet.sublime-syntax
@@ -62,7 +62,7 @@ contexts:
         - include: scope:source.scope-selector
       with_prototype:
         - match: '&amp;'
-          scope: keyword.operator.with.scope-selector
+          scope: keyword.operator.combinator.with.scope-selector
     - match: '(<)(tabTrigger)(>)'
       scope: meta.tag.xml
       captures:

--- a/Package/Sublime Text Snippet/Sublime Text Snippet.sublime-syntax
+++ b/Package/Sublime Text Snippet/Sublime Text Snippet.sublime-syntax
@@ -59,10 +59,7 @@ contexts:
           scope: invalid.illegal.newline-not-supported-here.sublime-snippet
         - match: '(?=</scope>)'
           pop: true
-        - include: scope:source.scope-selector
-      with_prototype:
-        - match: '&amp;'
-          scope: keyword.operator.combinator.with.scope-selector
+        - include: scope:source.scope-selector.xml
     - match: '(<)(tabTrigger)(>)'
       scope: meta.tag.xml
       captures:

--- a/Package/Sublime Text Snippet/syntax_test_snippet.xml
+++ b/Package/Sublime Text Snippet/syntax_test_snippet.xml
@@ -293,14 +293,14 @@ ${TM_CURRENT_LINE/^\\s*((?:\\/\1/}
 #      ^^^^ string.unquoted.scope-segment
 #          ^ punctuation.separator.scope-segments
 #           ^^^^ string.unquoted.scope-segment
-#                ^^^^^ keyword.operator.with.scope-selector
+#                ^^^^^ keyword.operator.combinator.with.scope-selector
 #                      ^^^^ string.unquoted.scope-segment
 <scope><![CDATA[text.html &amp; test]]></scope>
 #      ^^^^^^^^^ invalid.illegal
 #               ^^^^ string.unquoted.scope-segment
 #                   ^ punctuation.separator.scope-segments
 #                    ^^^^ string.unquoted.scope-segment
-#                         ^^^^^ keyword.operator.with
+#                         ^^^^^ keyword.operator.combinator.with
 #                               ^^^^ string.unquoted.scope-segment
 #                                   ^^^ invalid.illegal
 <scope>text.html &amp; test
@@ -312,18 +312,18 @@ ${TM_CURRENT_LINE/^\\s*((?:\\/\1/}
 #       ^^^^^^ string.unquoted.scope-segment.scope-selector
 #             ^ punctuation.separator.scope-segments.scope-selector
 #              ^ string.unquoted.scope-segment.scope-selector
-#                ^ keyword.operator.or.scope-selector
+#                ^ keyword.operator.combinator.or.scope-selector
 #                  ^^^^^^ string.unquoted.scope-segment.scope-selector
 #                        ^ punctuation.separator.scope-segments.scope-selector
 #                         ^^^ string.unquoted.scope-segment.scope-selector
 #                            ^ punctuation.section.group.end.scope-selector
-#                              ^^^^^ keyword.operator.with.scope-selector
+#                              ^^^^^ keyword.operator.combinator.with.scope-selector
 #                                    ^^^^^^ string.unquoted.scope-segment.scope-selector
-#                                          ^ keyword.operator.or.scope-selector
+#                                          ^ keyword.operator.combinator.or.scope-selector
 #                                            ^ punctuation.section.group.begin.scope-selector
-#                                             ^^^^^ keyword.operator.with.scope-selector
+#                                             ^^^^^ keyword.operator.combinator.with.scope-selector
 #                                                  ^ punctuation.section.group.end.scope-selector
-#                                                    ^ keyword.operator.or.scope-selector
+#                                                    ^ keyword.operator.combinator.or.scope-selector
 #                                                      ^^^^^^ string.unquoted.scope-segment.scope-selector
 
 <tabTrigger> </tabTrigger>

--- a/Package/TextMate Preferences/syntax_test_tmPreferences.xml
+++ b/Package/TextMate Preferences/syntax_test_tmPreferences.xml
@@ -54,15 +54,15 @@
 <!--                    ^ punctuation.definition.tag.begin.xml -->
 <!--                     ^^^^^^^^^^^^^^^^^^^^^^^ meta.string.selector.tmPreferences -->
 <!--                                            ^^^ punctuation.definition.tag.end.xml - meta.string - invalid -->
-<!--                         ^ keyword.operator.with.scope-selector -->
+<!--                         ^ keyword.operator.combinator.with.scope-selector -->
 <!--                           ^ punctuation.section.group.begin.scope-selector -->
-<!--                                      ^ keyword.operator.with.scope-selector -->
+<!--                                      ^ keyword.operator.combinator.with.scope-selector -->
 <!--                                           ^ punctuation.section.group.end.scope-selector -->
         <key>scope</key>
         <string>abc & (def - ghi & jkl &amp; mno)</string>
 <!--                ^ invalid.illegal.bad-ampersand.xml -->
 <!--                             ^ invalid.illegal.bad-ampersand.xml -->
-<!--                                   ^^^^^ constant.character.entity.xml keyword.operator.with.scope-selector -->
+<!--                                   ^^^^^ constant.character.entity.xml keyword.operator.combinator.with.scope-selector -->
 
         <key>settings</key>
 <!--         ^^^^^^^^ meta.inside-dict-key.plist keyword.other.settings.tmPreferences-->
@@ -255,7 +255,7 @@
 <!--                                                ^^^^^ string.unquoted.scope-segment.scope-selector -->
 <!--                                                     ^ punctuation.separator.scope-segments.scope-selector -->
 <!--                                                      ^^^^^ string.unquoted.scope-segment.scope-selector -->
-<!--                                                            ^^^^^ constant.character.entity.xml keyword.operator.with.scope-selector -->
+<!--                                                            ^^^^^ constant.character.entity.xml keyword.operator.combinator.with.scope-selector -->
 <!--                                                                  ^ punctuation.section.group.begin.scope-selector -->
 <!--                                                                           ^ invalid.illegal.missing-group-end.scope-selector -->
 <!--                                                                            ^^^^^^^^^ meta.tag.xml - meta.inside-value -->
@@ -275,12 +275,12 @@
 <!--                                                            ^^^^^^^^^^^^^^^ meta.group.scope-selector - meta.group meta.group -->
 <!--                            ^ punctuation.section.group.begin.scope-selector -->
 <!--                              ^ punctuation.section.group.begin.scope-selector -->
-<!--                                           ^ keyword.operator.or.scope-selector -->
+<!--                                           ^ keyword.operator.combinator.or.scope-selector -->
 <!--                                                           ^ punctuation.section.group.end.scope-selector -->
-<!--                                                             ^^^^^ constant.character.entity.xml keyword.operator.with.scope-selector -->
+<!--                                                             ^^^^^ constant.character.entity.xml keyword.operator.combinator.with.scope-selector -->
 <!--                                                                   ^^^^^^ string.unquoted.scope-segment.scope-selector -->
 <!--                                                                          ^ punctuation.section.group.end.scope-selector -->
-<!--                                                                            ^^^^^ constant.character.entity.xml keyword.operator.with.scope-selector -->
+<!--                                                                            ^^^^^ constant.character.entity.xml keyword.operator.combinator.with.scope-selector -->
 <!--                                                                                  ^^^^^^^^^^^ string.unquoted.scope-segment.scope-selector -->
 <!--                                                                                              ^^^^^^^^^^^^^^^^ comment.block.xml -->
                 </dict>

--- a/Package/syntax_test_scope_selector.txt
+++ b/Package/syntax_test_scope_selector.txt
@@ -20,7 +20,7 @@ string.quoted.double
 
 
  - quoted.double
-#^ keyword.operator.without.scope-selector
+#^ keyword.operator.combinator.without.scope-selector
 # ^ - keyword - string
 #  ^^^^^^ string.unquoted.scope-segment.scope-selector
 #        ^ punctuation.separator.scope-segments.scope-selector
@@ -29,56 +29,56 @@ string.quoted.double
  string - comment
 #^^^^^^ string.unquoted.scope-segment.scope-selector
 #      ^ - string - keyword
-#       ^ keyword.operator.without.scope-selector
+#       ^ keyword.operator.combinator.without.scope-selector
 #        ^ - string - keyword
 #         ^^^^^^^ string.unquoted.scope-segment.scope-selector
 
  string, comment
 #^^^^^^ string.unquoted.scope-segment.scope-selector
-#      ^ keyword.operator.or.scope-selector
+#      ^ keyword.operator.combinator.or.scope-selector
 #       ^ - string - keyword
 #        ^^^^^^^ string.unquoted.scope-segment.scope-selector
 
  string | comment
 #^^^^^^ string.unquoted.scope-segment.scope-selector
 #      ^ - string - keyword
-#       ^ keyword.operator.or.scope-selector
+#       ^ keyword.operator.combinator.or.scope-selector
 #        ^ - string - keyword
 #         ^^^^^^^ string.unquoted.scope-segment.scope-selector
 
  string & - comment
 #^^^^^^ string.unquoted.scope-segment.scope-selector
 #      ^ - string - keyword
-#       ^ keyword.operator.with.scope-selector
+#       ^ keyword.operator.combinator.with.scope-selector
 #        ^ - string - keyword
-#         ^ keyword.operator.without.scope-selector
+#         ^ keyword.operator.combinator.without.scope-selector
 #          ^ - string - keyword
 #           ^^^^^^^ string.unquoted.scope-segment.scope-selector
 
  source string
 #^^^^^^ string.unquoted.scope-segment.scope-selector
-#      ^ keyword.operator.right.scope-selector
+#      ^ keyword.operator.combinator.right.scope-selector
 #       ^^^^^^ string.unquoted.scope-segment.scope-selector
 
  source & (string - comment) &
 #^^^^^^ string.unquoted.scope-segment.scope-selector
 #      ^ - string - keyword
-#       ^ keyword.operator.with.scope-selector
+#       ^ keyword.operator.combinator.with.scope-selector
 #        ^ - string - keyword
 #         ^ punctuation.section.group.begin.scope-selector
 #          ^^^^^^ string.unquoted.scope-segment.scope-selector
 #                ^ - string - keyword
-#                 ^ keyword.operator.without.scope-selector
+#                 ^ keyword.operator.combinator.without.scope-selector
 #                  ^ - string - keyword
 #                   ^^^^^^^ string.unquoted.scope-segment.scope-selector
 #                          ^ punctuation.section.group.end.scope-selector
 #                           ^ - string - keyword
-#                            ^ keyword.operator.with.scope-selector
+#                            ^ keyword.operator.combinator.with.scope-selector
 
  string & source
 #^^^^^^ string.unquoted.scope-segment.scope-selector
 #      ^ - string - keyword
-#       ^ keyword.operator.with.scope-selector
+#       ^ keyword.operator.combinator.with.scope-selector
 #        ^ - string - keyword
 #         ^^^^^^ string.unquoted.scope-segment.scope-selector
 
@@ -86,7 +86,7 @@ string.quoted.double
 #^^^^^^ string.unquoted.scope-segment.scope-selector
 #      ^ punctuation.separator.scope-segments.scope-selector
 #       ^^^^^^ string.unquoted.scope-segment.scope-selector
-#             ^ keyword.operator.right.scope-selector
+#             ^ keyword.operator.combinator.right.scope-selector
 #              ^^^^^^ string.unquoted.scope-segment.scope-selector
 #                    ^ punctuation.separator.scope-segments.scope-selector
 #                     ^^^^^^ string.unquoted.scope-segment.scope-selector
@@ -96,7 +96,7 @@ string.quoted.double
 #                                   ^^^^^ string.unquoted.scope-segment.scope-selector
 #                                        ^ punctuation.separator.scope-segments.scope-selector
 #                                         ^^^^^^ string.unquoted.scope-segment.scope-selector
-#                                               ^ keyword.operator.right.scope-selector
+#                                               ^ keyword.operator.combinator.right.scope-selector
 #                                                ^^^^^^^^^^^ string.unquoted.scope-segment.scope-selector
 #                                                           ^ punctuation.separator.scope-segments.scope-selector
 #                                                            ^^^^^^^^^^ string.unquoted.scope-segment.scope-selector
@@ -110,11 +110,11 @@ string.quoted.double
  source & string & punctuation.definition.string.begin.python
 #^^^^^^ string.unquoted.scope-segment.scope-selector
 #      ^ - string - keyword
-#       ^ keyword.operator.with.scope-selector
+#       ^ keyword.operator.combinator.with.scope-selector
 #        ^ - string - keyword
 #         ^^^^^^ string.unquoted.scope-segment.scope-selector
 #               ^ - string - keyword
-#                ^ keyword.operator.with.scope-selector
+#                ^ keyword.operator.combinator.with.scope-selector
 #                 ^ - string - keyword
 #                  ^^^^^^^^^^^ string.unquoted.scope-segment.scope-selector
 #                             ^ punctuation.separator.scope-segments.scope-selector
@@ -128,10 +128,10 @@ string.quoted.double
 
  string punctuation & source
 #^^^^^^ string.unquoted.scope-segment.scope-selector
-#      ^ keyword.operator.right.scope-selector
+#      ^ keyword.operator.combinator.right.scope-selector
 #       ^^^^^^^^^^^ string.unquoted.scope-segment.scope-selector
 #                  ^ - string - keyword
-#                   ^ keyword.operator.with.scope-selector
+#                   ^ keyword.operator.combinator.with.scope-selector
 #                    ^ - string - keyword
 #                     ^^^^^^ string.unquoted.scope-segment.scope-selector
 
@@ -141,47 +141,47 @@ string.quoted.double
  (punctuation string) test.example - foo bar
 #^ punctuation.section.group.begin.scope-selector
 # ^^^^^^^^^^^ string.unquoted.scope-segment.scope-selector
-#            ^ keyword.operator.right.scope-selector
+#            ^ keyword.operator.combinator.right.scope-selector
 #             ^^^^^^ string.unquoted.scope-segment.scope-selector
 #                   ^ punctuation.section.group.end.scope-selector
 #                    ^^^^^^^^^^^^^ invalid.illegal.operator-required-after-group.scope-selector
 #                                 ^ - string - keyword - illegal
-#                                  ^ keyword.operator.without.scope-selector
+#                                  ^ keyword.operator.combinator.without.scope-selector
 #                                   ^ - string - keyword - illegal
 #                                    ^^^ string.unquoted.scope-segment.scope-selector
-#                                       ^ keyword.operator.right.scope-selector
+#                                       ^ keyword.operator.combinator.right.scope-selector
 #                                        ^^^ string.unquoted.scope-segment.scope-selector
 
  (source&string)
 #^ punctuation.section.group.begin.scope-selector
 # ^^^^^^ string.unquoted.scope-segment.scope-selector
-#       ^ keyword.operator.with.scope-selector
+#       ^ keyword.operator.combinator.with.scope-selector
 #        ^^^^^^ string.unquoted.scope-segment.scope-selector
 #              ^ punctuation.section.group.end.scope-selector
 
  (punctuation|string)&source.python -comment
 #^ punctuation.section.group.begin.scope-selector
 # ^^^^^^^^^^^ string.unquoted.scope-segment.scope-selector
-#            ^ keyword.operator.or.scope-selector
+#            ^ keyword.operator.combinator.or.scope-selector
 #             ^^^^^^ string.unquoted.scope-segment.scope-selector
 #                   ^ punctuation.section.group.end.scope-selector
-#                    ^ keyword.operator.with.scope-selector
+#                    ^ keyword.operator.combinator.with.scope-selector
 #                     ^^^^^^ string.unquoted.scope-segment.scope-selector
 #                           ^ punctuation.separator.scope-segments.scope-selector
 #                            ^^^^^^ string.unquoted.scope-segment.scope-selector
 #                                  ^ - string - keyword
-#                                   ^ keyword.operator.without.scope-selector
+#                                   ^ keyword.operator.combinator.without.scope-selector
 #                                    ^^^^^^^ string.unquoted.scope-segment.scope-selector
 
  comment,string|source
 #^^^^^^^ string.unquoted.scope-segment.scope-selector
-#       ^ keyword.operator.or.scope-selector
+#       ^ keyword.operator.combinator.or.scope-selector
 #        ^^^^^^ string.unquoted.scope-segment.scope-selector
-#              ^ keyword.operator.or.scope-selector
+#              ^ keyword.operator.combinator.or.scope-selector
 #               ^^^^^^ string.unquoted.scope-segment.scope-selector
 
 -comment
-#<- keyword.operator.without.scope-selector
+#<- keyword.operator.combinator.without.scope-selector
 #^^^^^^^ string.unquoted.scope-segment.scope-selector
 
 ( text )|source
@@ -190,13 +190,13 @@ string.quoted.double
 # ^^^^ string.unquoted.scope-segment.scope-selector
 #     ^ - string - keyword
 #      ^ punctuation.section.group.end.scope-selector
-#       ^ keyword.operator.or.scope-selector
+#       ^ keyword.operator.combinator.or.scope-selector
 #        ^^^^^^ string.unquoted.scope-segment.scope-selector
 
 (trailing space)
 #<- punctuation.section.group.begin.scope-selector
 #^^^^^^^^ string.unquoted.scope-segment.scope-selector
-#        ^ keyword.operator.right.scope-selector
+#        ^ keyword.operator.combinator.right.scope-selector
 #         ^^^^^ string.unquoted.scope-segment.scope-selector
 #              ^ punctuation.section.group.end.scope-selector
 #               ^^ - string - keyword - illegal
@@ -211,17 +211,17 @@ text.html - (source & - source text.html)
 #   ^ punctuation.separator.scope-segments.scope-selector
 #    ^^^^ string.unquoted.scope-segment.scope-selector
 #        ^ - string - keyword
-#         ^ keyword.operator.without.scope-selector
+#         ^ keyword.operator.combinator.without.scope-selector
 #          ^ - string - keyword
 #           ^ punctuation.section.group.begin.scope-selector
 #            ^^^^^^ string.unquoted.scope-segment.scope-selector
 #                  ^ - string - keyword
-#                   ^ keyword.operator.with.scope-selector
+#                   ^ keyword.operator.combinator.with.scope-selector
 #                    ^ - string - keyword
-#                     ^ keyword.operator.without.scope-selector
+#                     ^ keyword.operator.combinator.without.scope-selector
 #                      ^ - string - keyword
 #                       ^^^^^^ string.unquoted.scope-segment.scope-selector
-#                             ^ keyword.operator.right.scope-selector
+#                             ^ keyword.operator.combinator.right.scope-selector
 #                              ^^^^ string.unquoted.scope-segment.scope-selector
 #                                  ^ punctuation.separator.scope-segments.scope-selector
 #                                   ^^^^ string.unquoted.scope-segment.scope-selector
@@ -232,12 +232,12 @@ source.php - source.php text.html
 #     ^ punctuation.separator.scope-segments.scope-selector
 #      ^^^ string.unquoted.scope-segment.scope-selector
 #         ^ - string - keyword
-#          ^ keyword.operator.without.scope-selector
+#          ^ keyword.operator.combinator.without.scope-selector
 #           ^ - string - keyword
 #            ^^^^^^ string.unquoted.scope-segment.scope-selector
 #                  ^ punctuation.separator.scope-segments.scope-selector
 #                   ^^^ string.unquoted.scope-segment.scope-selector
-#                      ^ keyword.operator.right.scope-selector
+#                      ^ keyword.operator.combinator.right.scope-selector
 #                       ^^^^ string.unquoted.scope-segment.scope-selector
 #                           ^ punctuation.separator.scope-segments.scope-selector
 #                            ^^^^ string.unquoted.scope-segment.scope-selector
@@ -246,26 +246,26 @@ embedding.php text.html - (source.php &amp; - source.php text.html)
 #^^^^^^^^ string.unquoted.scope-segment.scope-selector
 #        ^ punctuation.separator.scope-segments.scope-selector
 #         ^^^ string.unquoted.scope-segment.scope-selector
-#            ^ keyword.operator.right.scope-selector
+#            ^ keyword.operator.combinator.right.scope-selector
 #             ^^^^ string.unquoted.scope-segment.scope-selector
 #                 ^ punctuation.separator.scope-segments.scope-selector
 #                  ^^^^ string.unquoted.scope-segment.scope-selector
 #                      ^ - string - keyword
-#                       ^ keyword.operator.without.scope-selector
+#                       ^ keyword.operator.combinator.without.scope-selector
 #                        ^ - string - keyword
 #                         ^ punctuation.section.group.begin.scope-selector
 #                          ^^^^^^ string.unquoted.scope-segment.scope-selector
 #                                ^ punctuation.separator.scope-segments.scope-selector
 #                                 ^^^ string.unquoted.scope-segment.scope-selector
 #                                    ^ - string - keyword
-#                                     ^ keyword.operator.with.scope-selector
+#                                     ^ keyword.operator.combinator.with.scope-selector
 #                                          ^ - string - keyword
-#                                           ^ keyword.operator.without.scope-selector
+#                                           ^ keyword.operator.combinator.without.scope-selector
 #                                            ^ - string - keyword
 #                                             ^^^^^^ string.unquoted.scope-segment.scope-selector
 #                                                   ^ punctuation.separator.scope-segments.scope-selector
 #                                                    ^^^ string.unquoted.scope-segment.scope-selector
-#                                                       ^ keyword.operator.right.scope-selector
+#                                                       ^ keyword.operator.combinator.right.scope-selector
 #                                                        ^^^^ string.unquoted.scope-segment.scope-selector
 #                                                            ^ punctuation.separator.scope-segments.scope-selector
 #                                                             ^^^^ string.unquoted.scope-segment.scope-selector
@@ -275,3 +275,17 @@ source.c++
 # ^^^^ string.unquoted.scope-segment.scope-selector
 #     ^ punctuation.separator.scope-segments.scope-selector
 #      ^^^ string.unquoted.scope-segment.scope-selector
+
+source.c > parent & (parent > child)
+#^^^^^ string.unquoted.scope-segment.scope-selector
+#     ^ punctuation.separator.scope-segments.scope-selector
+#      ^ string.unquoted.scope-segment.scope-selector
+#        ^ keyword.operator.combinator.child.scope-selector
+#          ^^^^^^ string.unquoted.scope-segment.scope-selector
+#                 ^ keyword.operator.combinator.with.scope-selector
+#                   ^^^^^^^^^^^^^^^^ meta.group.scope-selector
+#                   ^ punctuation.section.group.begin.scope-selector
+#                    ^^^^^^ string.unquoted.scope-segment.scope-selector
+#                           ^ keyword.operator.combinator.child.scope-selector
+#                             ^^^^^ string.unquoted.scope-segment.scope-selector
+#                                  ^ punctuation.section.group.end.scope-selector

--- a/Package/syntax_test_scope_selector.txt
+++ b/Package/syntax_test_scope_selector.txt
@@ -57,7 +57,7 @@ string.quoted.double
 
  source string
 #^^^^^^ string.unquoted.scope-segment.scope-selector
-#      ^ keyword.operator.combinator.right.scope-selector
+#      ^ keyword.operator.combinator.descendent.scope-selector
 #       ^^^^^^ string.unquoted.scope-segment.scope-selector
 
  source & (string - comment) &
@@ -86,7 +86,7 @@ string.quoted.double
 #^^^^^^ string.unquoted.scope-segment.scope-selector
 #      ^ punctuation.separator.scope-segments.scope-selector
 #       ^^^^^^ string.unquoted.scope-segment.scope-selector
-#             ^ keyword.operator.combinator.right.scope-selector
+#             ^ keyword.operator.combinator.descendent.scope-selector
 #              ^^^^^^ string.unquoted.scope-segment.scope-selector
 #                    ^ punctuation.separator.scope-segments.scope-selector
 #                     ^^^^^^ string.unquoted.scope-segment.scope-selector
@@ -96,7 +96,7 @@ string.quoted.double
 #                                   ^^^^^ string.unquoted.scope-segment.scope-selector
 #                                        ^ punctuation.separator.scope-segments.scope-selector
 #                                         ^^^^^^ string.unquoted.scope-segment.scope-selector
-#                                               ^ keyword.operator.combinator.right.scope-selector
+#                                               ^ keyword.operator.combinator.descendent.scope-selector
 #                                                ^^^^^^^^^^^ string.unquoted.scope-segment.scope-selector
 #                                                           ^ punctuation.separator.scope-segments.scope-selector
 #                                                            ^^^^^^^^^^ string.unquoted.scope-segment.scope-selector
@@ -128,7 +128,7 @@ string.quoted.double
 
  string punctuation & source
 #^^^^^^ string.unquoted.scope-segment.scope-selector
-#      ^ keyword.operator.combinator.right.scope-selector
+#      ^ keyword.operator.combinator.descendent.scope-selector
 #       ^^^^^^^^^^^ string.unquoted.scope-segment.scope-selector
 #                  ^ - string - keyword
 #                   ^ keyword.operator.combinator.with.scope-selector
@@ -141,7 +141,7 @@ string.quoted.double
  (punctuation string) test.example - foo bar
 #^ punctuation.section.group.begin.scope-selector
 # ^^^^^^^^^^^ string.unquoted.scope-segment.scope-selector
-#            ^ keyword.operator.combinator.right.scope-selector
+#            ^ keyword.operator.combinator.descendent.scope-selector
 #             ^^^^^^ string.unquoted.scope-segment.scope-selector
 #                   ^ punctuation.section.group.end.scope-selector
 #                    ^^^^^^^^^^^^^ invalid.illegal.operator-required-after-group.scope-selector
@@ -149,7 +149,7 @@ string.quoted.double
 #                                  ^ keyword.operator.combinator.without.scope-selector
 #                                   ^ - string - keyword - illegal
 #                                    ^^^ string.unquoted.scope-segment.scope-selector
-#                                       ^ keyword.operator.combinator.right.scope-selector
+#                                       ^ keyword.operator.combinator.descendent.scope-selector
 #                                        ^^^ string.unquoted.scope-segment.scope-selector
 
  (source&string)
@@ -196,7 +196,7 @@ string.quoted.double
 (trailing space)
 #<- punctuation.section.group.begin.scope-selector
 #^^^^^^^^ string.unquoted.scope-segment.scope-selector
-#        ^ keyword.operator.combinator.right.scope-selector
+#        ^ keyword.operator.combinator.descendent.scope-selector
 #         ^^^^^ string.unquoted.scope-segment.scope-selector
 #              ^ punctuation.section.group.end.scope-selector
 #               ^^ - string - keyword - illegal
@@ -221,7 +221,7 @@ text.html - (source & - source text.html)
 #                     ^ keyword.operator.combinator.without.scope-selector
 #                      ^ - string - keyword
 #                       ^^^^^^ string.unquoted.scope-segment.scope-selector
-#                             ^ keyword.operator.combinator.right.scope-selector
+#                             ^ keyword.operator.combinator.descendent.scope-selector
 #                              ^^^^ string.unquoted.scope-segment.scope-selector
 #                                  ^ punctuation.separator.scope-segments.scope-selector
 #                                   ^^^^ string.unquoted.scope-segment.scope-selector
@@ -237,7 +237,7 @@ source.php - source.php text.html
 #            ^^^^^^ string.unquoted.scope-segment.scope-selector
 #                  ^ punctuation.separator.scope-segments.scope-selector
 #                   ^^^ string.unquoted.scope-segment.scope-selector
-#                      ^ keyword.operator.combinator.right.scope-selector
+#                      ^ keyword.operator.combinator.descendent.scope-selector
 #                       ^^^^ string.unquoted.scope-segment.scope-selector
 #                           ^ punctuation.separator.scope-segments.scope-selector
 #                            ^^^^ string.unquoted.scope-segment.scope-selector
@@ -246,7 +246,7 @@ embedding.php text.html - (source.php &amp; - source.php text.html)
 #^^^^^^^^ string.unquoted.scope-segment.scope-selector
 #        ^ punctuation.separator.scope-segments.scope-selector
 #         ^^^ string.unquoted.scope-segment.scope-selector
-#            ^ keyword.operator.combinator.right.scope-selector
+#            ^ keyword.operator.combinator.descendent.scope-selector
 #             ^^^^ string.unquoted.scope-segment.scope-selector
 #                 ^ punctuation.separator.scope-segments.scope-selector
 #                  ^^^^ string.unquoted.scope-segment.scope-selector
@@ -265,7 +265,7 @@ embedding.php text.html - (source.php &amp; - source.php text.html)
 #                                             ^^^^^^ string.unquoted.scope-segment.scope-selector
 #                                                   ^ punctuation.separator.scope-segments.scope-selector
 #                                                    ^^^ string.unquoted.scope-segment.scope-selector
-#                                                       ^ keyword.operator.combinator.right.scope-selector
+#                                                       ^ keyword.operator.combinator.descendent.scope-selector
 #                                                        ^^^^ string.unquoted.scope-segment.scope-selector
 #                                                            ^ punctuation.separator.scope-segments.scope-selector
 #                                                             ^^^^ string.unquoted.scope-segment.scope-selector


### PR DESCRIPTION
This commit adds...

1. a common `.combinator` 3rd-level scope, following the schema of CSS.
2. the `>` child combinator operator supported as of ST4201.