### PR TITLE
Use safe_load in commandinfo

### DIFF
--- a/plugins/command_completions/commandinfo.py
+++ b/plugins/command_completions/commandinfo.py
@@ -32,7 +32,7 @@ def get_command_name(command_class):
     last_upper = False
     for c in clsname[1:]:
         if c.isupper() and not last_upper:
-            name += '_'
+            name += "_"
             name += c.lower()
         else:
             name += c
@@ -58,7 +58,7 @@ def get_builtin_command_meta_data():
     for res_path in res_paths:
         try:
             res_raw = sublime.load_resource(res_path)
-            res_meta, res_data = yaml.load_all(res_raw, Loader=SaveOmapLoader)
+            res_meta, res_data = yaml.safe_safe_load_all(res_raw, Loader=SaveOmapLoader)
         except (OSError, ValueError):
             logger.exception("couldn't load resource: %s", res_path)
         else:
@@ -86,22 +86,21 @@ def get_builtin_commands(command_type=""):
     if not command_type:
         result = frozenset(data.keys())
     else:
-        result = frozenset(k for k, v in data.items()
-                           if v['command_type'] == command_type)
+        result = frozenset(
+            k for k, v in data.items() if v["command_type"] == command_type
+        )
 
-    should_check_outdated = int(sublime.version()) >= meta.get('build', 1e10)
+    should_check_outdated = int(sublime.version()) >= meta.get("build", 1e10)
     for c in iter_python_command_classes(command_type):
         name = get_command_name(c)
         module = c.__module__
         package = module.split(".")[0]
-        if (
-            should_check_outdated
-            and package == 'Default'
-            and name in result
-        ):
+        if should_check_outdated and package == "Default" and name in result:
             logger.warning(
                 'command "{name}" in the {package} package is defined in the built-in'
-                ' metadata file. Probably it should not be'.format(name=name, package=package)
+                " metadata file. Probably it should not be".format(
+                    name=name, package=package
+                )
             )
 
     return result
@@ -125,7 +124,7 @@ def iter_python_command_classes(command_type=""):
         cmd_list = {
             "text": sublime_plugin.text_command_classes,
             "window": sublime_plugin.window_command_classes,
-            "app": sublime_plugin.application_command_classes
+            "app": sublime_plugin.application_command_classes,
         }[command_type]
         yield from iter(cmd_list)
 
@@ -146,17 +145,25 @@ def extract_command_class_args(command_class):
     args = spec.args
     defaults = spec.defaults or ()
     num_non_default_args = len(args) - len(defaults)
-    logger.debug("Args for command %r: %s; defaults: %s",
-                 get_command_name(command_class), args, defaults)
+    logger.debug(
+        "Args for command %r: %s; defaults: %s",
+        get_command_name(command_class),
+        args,
+        defaults,
+    )
 
     arg_dict = OrderedDict()
     for i, arg in enumerate(args):
         if i == 0:  # strip 'self' arg
             continue
-        elif i == 1 and issubclass(command_class, sublime_plugin.TextCommand):  # and 'edit'
+        elif i == 1 and issubclass(
+            command_class, sublime_plugin.TextCommand
+        ):  # and 'edit'
             if arg != "edit":
-                logger.warning("Second argument for TextCommand is not named 'edit'."
-                               " Ignoring anyway")
+                logger.warning(
+                    "Second argument for TextCommand is not named 'edit'."
+                    " Ignoring anyway"
+                )
             continue
         elif i < num_non_default_args:
             value = None
@@ -178,9 +185,12 @@ def find_class_from_command_name(command_name):
         The python class, which belongs to the command name, or None.
     """
     return next(
-        (c for c in iter_python_command_classes()
-         if get_command_name(c) == command_name),
-        None
+        (
+            c
+            for c in iter_python_command_classes()
+            if get_command_name(c) == command_name
+        ),
+        None,
     )
 
 


### PR DESCRIPTION
`yaml.load()` in `plugins/command_completions/commandinfo.py` doesn't pass a safe Loader. This can deserialize arbitrary Python objects and is an RCE risk if the YAML comes from user input or the network. Switched to `yaml.safe_load()`.