### PR TITLE
fix(keymap syntax):  error highlighting on "control" as modifier key...

### DIFF
--- a/Package/Sublime Text Keymap/Sublime Text Keymap.sublime-syntax
+++ b/Package/Sublime Text Keymap/Sublime Text Keymap.sublime-syntax
@@ -7,7 +7,7 @@ file_extensions:
 scope: source.json.sublime.keymap
 
 variables:
-  modifiers: (?:shift|ctrl|alt|altgr|super|command|option|primary)
+  modifiers: (?:shift|ctrl|control|alt|altgr|super|command|option|primary)
 
 contexts:
   main:


### PR DESCRIPTION
...Sublime Text accepts it.  This PR takes away the error highlighting when "control" is used as a modifier key in a `.sublime-keymap` file.  Recommended UNLESS Sublime Text has (or will) deprecate the use of that modifier-key name.

Fixes #431