### PR TITLE
Adjust some scopes in Sublime Syntax Definitions

### DIFF
--- a/Package/Sublime Text Syntax Definition/References - Variable.tmPreferences
+++ b/Package/Sublime Text Syntax Definition/References - Variable.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>source.yaml.sublime.syntax keyword.other.variable variable.other</string>
+    <string>source.yaml.sublime.syntax variable.other.constant</string>
     <key>settings</key>
     <dict>
         <key>showInIndexedReferenceList</key>

--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-settings
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-settings
@@ -5,7 +5,7 @@
     "auto_complete_triggers": [
         { "selector": "punctuation.separator.scope-segments.sublime-syntax" },
     ],
-    "auto_complete_selector": "source - comment - (source.regexp - keyword.other.variable)",
+    "auto_complete_selector": "source - comment - (source.regexp - meta.interpolation)",
     "tab_size": 2,
     "translate_tabs_to_spaces": true,
     "trim_trailing_white_space_on_save": true,

--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
@@ -551,7 +551,7 @@ contexts:
               pop: true
         # local includes
         - match: '[\w-]+{{_flow_scalar_end_plain_in}}'  # matches until first '/' or ',' or ']'
-          scope: variable.other.sublime-syntax
+          scope: variable.other.context.sublime-syntax
         # We don't recognize this anything else, so just match as string
         - match: ''
           set:

--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
@@ -775,11 +775,11 @@ contexts:
 
   regexp_variable:
     - match: '(\{\{)([a-zA-Z_0-9]+)(\}\})'
-      scope: meta.variable.sublime-syntax keyword.other.variable.sublime-syntax
+      scope: meta.interpolation.sublime-syntax
       captures:
-        1: punctuation.definition.variable.begin.sublime-syntax
+        1: punctuation.section.interpolation.begin.sublime-syntax
         2: variable.other.constant.sublime-syntax
-        3: punctuation.definition.variable.end.sublime-syntax
+        3: punctuation.section.interpolation.end.sublime-syntax
       push: regexp_quantifier_pop
 
   regexp_quantifier_pop:

--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
@@ -778,7 +778,7 @@ contexts:
       scope: meta.variable.sublime-syntax keyword.other.variable.sublime-syntax
       captures:
         1: punctuation.definition.variable.begin.sublime-syntax
-        2: variable.other.sublime-syntax
+        2: variable.other.constant.sublime-syntax
         3: punctuation.definition.variable.end.sublime-syntax
       push: regexp_quantifier_pop
 

--- a/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
+++ b/Package/Sublime Text Syntax Definition/Sublime Text Syntax Definition.sublime-syntax
@@ -263,7 +263,7 @@ contexts:
           pop: true
         - match: ''
           set:
-            - meta_scope: string.unquoted.plain.out.yaml entity.name.function.context.sublime-syntax
+            - meta_scope: string.unquoted.plain.out.yaml entity.name.class.context.sublime-syntax
             - match: '{{_flow_scalar_end_plain_out}}'
               pop: true
 

--- a/Package/Sublime Text Syntax Definition/Symbols - Context.tmPreferences
+++ b/Package/Sublime Text Syntax Definition/Symbols - Context.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>source.yaml.sublime.syntax entity.name.function.context</string>
+    <string>source.yaml.sublime.syntax entity.name.class.context</string>
     <key>settings</key>
     <dict>
         <key>showInSymbolList</key>

--- a/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
+++ b/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
@@ -166,7 +166,7 @@ contexts:
 # <- meta.block.contexts keyword.control.flow.contexts.sublime-syntax - meta.block.variables
 
   main:
-# ^^^^ entity.name.function.context.sublime-syntax
+# ^^^^ entity.name.class.context.sublime-syntax
     - include: scope:source.json
 #     ^^^^^^^ string.unquoted.plain.out.yaml keyword.operator.include.sublime-syntax
       apply_prototype: true
@@ -177,15 +177,15 @@ contexts:
 #<- - meta.expect-include - meta.expect-context-list-or-content - meta.expect-context-list
 
   context_name:
-# ^^^^^^^^^^^^ entity.name.function.context.sublime-syntax
+# ^^^^^^^^^^^^ entity.name.class.context.sublime-syntax
     - captures:
 #     ^^^^^^^^ string.unquoted.plain.out.yaml storage.type.captures.sublime-syntax
         1: name
   another_context_name:
-# ^ entity.name.function.context.sublime-syntax
+# ^ entity.name.class.context.sublime-syntax
     - captures:
   another_context_name:
-# ^ entity.name.function.context.sublime-syntax
+# ^ entity.name.class.context.sublime-syntax
 
     - meta_append: true
 #     ^^^^^^^^^^^ storage.modifier.context-extension.sublime-syntax
@@ -390,7 +390,7 @@ contexts: !mytag
 #^^^^^^^ string.unquoted.plain.out.yaml keyword.control.flow.contexts.sublime-syntax
 #         ^^^^^^ storage.type.tag-handle.yaml
   main: !mytag
-# ^^^^ entity.name.function.context.sublime-syntax
+# ^^^^ entity.name.class.context.sublime-syntax
 #       ^^^^^^ storage.type.tag-handle.yaml
     - match: !mytag abc+
 #     ^^^^^ keyword.other.match.sublime-syntax

--- a/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
+++ b/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
@@ -82,8 +82,10 @@ variables:
 
 
   x9: '{{im_a_variable}}'
-#      ^^^^^^^^^^^^^^^^^ meta.variable.sublime-syntax keyword.other.variable.sublime-syntax
+#      ^^^^^^^^^^^^^^^^^ meta.interpolation.sublime-syntax
+#      ^^ punctuation.section.interpolation.begin.sublime-syntax
 #        ^^^^^^^^^^^^^ variable.other.constant.sublime-syntax
+#                     ^^ punctuation.section.interpolation.end.sublime-syntax
 
   x10: '''{{identifier}}(?!\'')\b'
 #       ^^ constant.character.escape.yaml
@@ -149,7 +151,7 @@ variables:
         | {{duration_units}}
         | {{frequency_units}}
         | {{resolution_units}} )\b
-#         ^^^^^^^^^^^^^^^^^^^^ meta.variable.sublime-syntax keyword.other.variable.sublime-syntax
+#         ^^^^^^^^^^^^^^^^^^^^ meta.interpolation.sublime-syntax
 #           ^^^^^^^^^^^^^^^^ variable.other.constant.sublime-syntax
 
   'null': |-

--- a/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
+++ b/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
@@ -203,12 +203,12 @@ contexts:
 #              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.include.sublime-syntax string
 #              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ support.module.file-path.sublime-syntax
 #                                               ^ punctuation.separator.context-name.sublime-syntax - comment
-#                                                ^^^^^^^ variable.other.sublime-syntax
+#                                                ^^^^^^^ variable.other.context.sublime-syntax
     - include: JSON.sublime-syntax#comments
 #<- - meta.expect-include - meta.expect-context-list-or-content - meta.expect-context-list
 #              ^^^^^^^^^^^^^^^^^^^ support.module.file-path.sublime-syntax
 #                                 ^ punctuation.separator.context-name.sublime-syntax
-#                                  ^^^^^^^ variable.other.sublime-syntax
+#                                  ^^^^^^^ variable.other.context.sublime-syntax
 
     - include: Packages/JSON/ #JSON.sublime-syntax#comment
 #<- - meta.expect-include - meta.expect-context-list-or-content - meta.expect-context-list
@@ -218,7 +218,7 @@ contexts:
 #              ^^^^^^ support.type.include.sublime-syntax
 #                   ^ punctuation.definition.scope-include.sublime-syntax
 #                                           ^ punctuation.separator.context-name.sublime-syntax - comment
-#                                            ^^^^^^^^^^^^^^^^^^^ variable.other.sublime-syntax
+#                                            ^^^^^^^^^^^^^^^^^^^ variable.other.context.sublime-syntax
 
     - push: [main, Packages/JSON/JSON.sublime-syntax#comment]
 #<- - meta.expect-include - meta.expect-context-list-or-content - meta.expect-context-list
@@ -231,7 +231,7 @@ contexts:
 #                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.include.sublime-syntax string
 #                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ support.module.file-path.sublime-syntax
 #                                                   ^ punctuation.separator.context-name.sublime-syntax
-#                                                    ^^^^^^^ variable.other.sublime-syntax
+#                                                    ^^^^^^^ variable.other.context.sublime-syntax
 #                                                           ^ punctuation.definition.array.end.sublime-syntax
       set: Packages/JSON/JSON.sublime-syntax#comment
 #    ^ - meta.expect-include - meta.expect-context-list-or-content - meta.expect-context-list
@@ -399,7 +399,7 @@ contexts: !mytag
       push: !mytag scope
 #     ^^^^ keyword.control.flow.push.sublime-syntax
 #           ^^^^^^ storage.type.tag-handle.yaml
-#                  ^^^^^ variable.other.sublime-syntax
+#                  ^^^^^ variable.other.context.sublime-syntax
       pop: !mytag true
 #     ^^^ keyword.control.flow.pop.sublime-syntax
 #          ^^^^^^ storage.type.tag-handle.yaml
@@ -411,16 +411,16 @@ contexts: !mytag
       push:
         !mytag scope
 #       ^^^^^^ storage.type.tag-handle.yaml
-#              ^^^^^ variable.other.sublime-syntax
+#              ^^^^^ variable.other.context.sublime-syntax
 
     - match: foo
       push: scope
-#           ^^^^^ meta.include.sublime-syntax string.unquoted.plain.out.yaml variable.other.sublime-syntax
+#           ^^^^^ meta.include.sublime-syntax string.unquoted.plain.out.yaml variable.other.context.sublime-syntax
 
     - match: foo
       push:
         scope
-#       ^^^^^ meta.include.sublime-syntax string.unquoted.plain.out.yaml variable.other.sublime-syntax
+#       ^^^^^ meta.include.sublime-syntax string.unquoted.plain.out.yaml variable.other.context.sublime-syntax
 
     - match: foo
       push:
@@ -450,14 +450,14 @@ contexts: !mytag
 #         ^^^^^ meta.context-list-or-content meta.include.sublime-syntax - meta.expect-context-list-or-content
 #              ^ meta.context-list-or-content.sublime-syntax - meta.expect-context-list-or-content - meta.include
 #       ^ punctuation.definition.block.sequence.item.yaml
-#         ^^^^^ string.unquoted.plain.out.yaml variable.other.sublime-syntax
+#         ^^^^^ string.unquoted.plain.out.yaml variable.other.context.sublime-syntax
         - match
 #<- meta.context-list.sublime-syntax - meta.include - meta.expect-context-list-or-content - meta.context-list-or-content
 #       ^^ meta.context-list.sublime-syntax - meta.include
 #         ^^^^^ meta.context-list meta.include.sublime-syntax
 #              ^ meta.context-list.sublime-syntax - meta.include
 #       ^ punctuation.definition.block.sequence.item.yaml
-#         ^^^^^ string.unquoted.plain.out.yaml variable.other.sublime-syntax
+#         ^^^^^ string.unquoted.plain.out.yaml variable.other.context.sublime-syntax
         - scope:source.yaml
 #       ^^ meta.context-list.sublime-syntax - meta.include
 #         ^^^^^^^^^^^^^^^^^ meta.context-list meta.include.sublime-syntax
@@ -492,7 +492,7 @@ contexts: !mytag
 #       ^^ meta.context-list-or-content.sublime-syntax
 #         ^^^^^^^^^ meta.context-list-or-content.sublime-syntax meta.include.sublime-syntax
 #       ^ punctuation.definition.block.sequence.item.yaml
-#         ^^^^^^^^^ variable.other.sublime-syntax
+#         ^^^^^^^^^ variable.other.context.sublime-syntax
         - - meta_scope: meta
 #      ^ - meta.anonymous-context
 #       ^^^^^^^^^^^^^^^^^^^^^ meta.anonymous-context.sublime-syntax
@@ -508,13 +508,13 @@ contexts: !mytag
 #      ^^^ meta.context-list.sublime-syntax
 #         ^^^^^^^^^ meta.context-list.sublime-syntax meta.include.sublime-syntax
 #       ^ punctuation.definition.block.sequence.item.yaml
-#         ^^^^^^^^^ variable.other.sublime-syntax
+#         ^^^^^^^^^ variable.other.context.sublime-syntax
         - context-3
 #<- - meta.anonymous-context
 #      ^^^ meta.context-list.sublime-syntax
 #         ^^^^^^^^^ meta.context-list.sublime-syntax meta.include.sublime-syntax
 #       ^ punctuation.definition.block.sequence.item.yaml
-#         ^^^^^^^^^ variable.other.sublime-syntax
+#         ^^^^^^^^^ variable.other.context.sublime-syntax
 
     - match: foo
       push:
@@ -536,7 +536,7 @@ contexts: !mytag
       branch:
 #     ^^^^^^ string.unquoted.plain.out.yaml keyword.control.flow.push.sublime-syntax
         - a
-#         ^ string.unquoted.plain.out.yaml variable.other.sublime-syntax
+#         ^ string.unquoted.plain.out.yaml variable.other.context.sublime-syntax
         - b
       fail: point
 #     ^ string.unquoted.plain.out.yaml keyword.control.flow.break.sublime-syntax

--- a/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
+++ b/Package/Sublime Text Syntax Definition/syntax_test_sublime-syntax.yaml
@@ -83,7 +83,7 @@ variables:
 
   x9: '{{im_a_variable}}'
 #      ^^^^^^^^^^^^^^^^^ meta.variable.sublime-syntax keyword.other.variable.sublime-syntax
-#        ^^^^^^^^^^^^^ variable.other.sublime-syntax
+#        ^^^^^^^^^^^^^ variable.other.constant.sublime-syntax
 
   x10: '''{{identifier}}(?!\'')\b'
 #       ^^ constant.character.escape.yaml
@@ -150,7 +150,7 @@ variables:
         | {{frequency_units}}
         | {{resolution_units}} )\b
 #         ^^^^^^^^^^^^^^^^^^^^ meta.variable.sublime-syntax keyword.other.variable.sublime-syntax
-#           ^^^^^^^^^^^^^^^^ variable.other.sublime-syntax
+#           ^^^^^^^^^^^^^^^^ variable.other.constant.sublime-syntax
 
   'null': |-
 # ^^^^^^ string.quoted.single.yaml

--- a/plugins/syntax_dev/completions.py
+++ b/plugins/syntax_dev/completions.py
@@ -237,7 +237,7 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
         result = None
 
         # None of our business
-        if not match_selector("- comment - (source.regexp - keyword.other.variable)"):
+        if not match_selector("- comment - (source.regexp - meta.interpolation)"):
             result = None
 
         # Scope name completions based on our scope_data database
@@ -275,7 +275,7 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
             result = self._complete_syntax_file()
 
         # Auto-completion for variables in match patterns using 'variables' keys
-        elif match_selector("keyword.other.variable"):
+        elif match_selector("meta.interpolation"):
             result = self._complete_variable()
 
         else:

--- a/plugins/syntax_dev/completions.py
+++ b/plugins/syntax_dev/completions.py
@@ -54,7 +54,7 @@ TPL_BRANCH = CompletionTemplate(
 )
 TPL_CONTEXT = CompletionTemplate(
     format=sublime.COMPLETION_FORMAT_SNIPPET,
-    kind=(sublime.KIND_ID_KEYWORD, 'c', 'Context'),
+    kind=(sublime.KIND_ID_TYPE, 'c', 'Context'),
     suffix=":\n  ",
 )
 TPL_FUNCTION = CompletionTemplate(
@@ -302,7 +302,7 @@ class SyntaxDefCompletionsListener(sublime_plugin.ViewEventListener):
 
         return format_completions(
             [(self.view.substr(r), self.view.rowcol(r.begin())[0] + 1)
-             for r in self.view.find_by_selector("entity.name.function.context")],
+             for r in self.view.find_by_selector("entity.name.class.context")],
             annotation="",
             kind=TPL_CONTEXT.kind,
         )


### PR DESCRIPTION
This PR proposes to...

1. introduce unique scopes for context, branch_point and global variables.

    - `variable.other.branch_point` - branch point references
    - `variable.other.constant` - global variables
    - `variable.other.context` - context names
    
   Goal: Plugins, snippets and completions should be able to address all of them easily.
 
2. scopes `{{...}}` expressions `meta.interpolation` instead of `keyword.other.variable`.
  
3. change scope of context name from `entity.name.function` to `entity.name.class`

   to ensure _Goto Symbol_ quick panel displays `c` kind icon, as auto-completion popup does.
   
   The completion items' kind icon is changed to use KIND_ID_TYPE, to ensure both, 
   _Goto Symbol_ quick panel and auto-completion popup display `c` with same color.
   
   Goal: Better visual consistency.

