### PR TITLE
Update sublime-keymap context vars completions

### DIFF
--- a/Package/Sublime Text Keymap/Completions/Context Key Values.sublime-completions
+++ b/Package/Sublime Text Keymap/Completions/Context Key Values.sublime-completions
@@ -4,12 +4,17 @@
 	"completions": [
 		{
 			"trigger": "num_selections",
-			"details": "Number of selections",
+			"details": "Number of selections in current buffer",
+			"kind": ["variable", "k", "key"],
+		},
+		{
+			"trigger": "auto_complete_primed",
+			"details": "Completion popup visibility",
 			"kind": ["variable", "k", "key"],
 		},
 		{
 			"trigger": "auto_complete_visible",
-			"details": "Completion popup visibility",
+			"details": "Mini auto-complete or completion popup visible; completion query active",
 			"kind": ["variable", "k", "key"],
 		},
 		{
@@ -38,6 +43,11 @@
 			"kind": ["variable", "k", "key"],
 		},
 		{
+			"trigger": "is_recording_macro",
+			"details": "If a macro is currently being recorded",
+			"kind": ["variable", "k", "key"],
+		},
+		{
 			"trigger": "panel_visible",
 			"details": "Panel visibility",
 			"kind": ["variable", "k", "key"],
@@ -63,6 +73,11 @@
 			"kind": ["variable", "k", "key"],
 		},
 		{
+			"trigger": "last_modifying_command",
+			"details": "Name of the last command run that modified a buffer",
+			"kind": ["variable", "k", "key"],
+		},
+		{
 			"trigger": "text",
 			"details": "Selection text",
 			"kind": ["variable", "k", "key"],
@@ -80,6 +95,16 @@
 		{
 			"trigger": "panel_has_focus",
 			"details": "Panel is visible and has focus",
+			"kind": ["variable", "k", "key"],
+		},
+		{
+			"trigger": "panel_type",
+			"details": "Type of focused panel",
+			"kind": ["variable", "k", "key"],
+		},
+		{
+			"trigger": "read_only",
+			"details": "If the buffer is marked read only",
 			"kind": ["variable", "k", "key"],
 		},
 		{
@@ -119,8 +144,9 @@
 		},
 		{
 			"trigger": "is_javadoc",
-			// "details": "TODO",
+			"details": "Caret in <code>/**</code> block comment",
 			"kind": ["variable", "k", "key"],
-		}
+		},
+
 	]
 }

--- a/Package/Sublime Text Keymap/Completions/Context Key Values.sublime-completions
+++ b/Package/Sublime Text Keymap/Completions/Context Key Values.sublime-completions
@@ -3,11 +3,6 @@
 
 	"completions": [
 		{
-			"trigger": "num_selections",
-			"details": "Number of selections in current buffer",
-			"kind": ["variable", "k", "key"],
-		},
-		{
 			"trigger": "auto_complete_primed",
 			"details": "Completion popup visibility",
 			"kind": ["variable", "k", "key"],
@@ -18,18 +13,23 @@
 			"kind": ["variable", "k", "key"],
 		},
 		{
-			"trigger": "selection_empty",
-			"details": "Selection is empty",
-			"kind": ["variable", "k", "key"],
-		},
-		{
-			"trigger": "preceding_text",
-			"details": "Text prededing the caret",
+			"trigger": "eol_selector",
+			"details": "Match the scope at the end of the line",
 			"kind": ["variable", "k", "key"],
 		},
 		{
 			"trigger": "following_text",
 			"details": "Text following the caret",
+			"kind": ["variable", "k", "key"],
+		},
+		{
+			"trigger": "group_has_multiselect",
+			"details": "Group has multiselected tabs",
+			"kind": ["variable", "k", "key"],
+		},
+		{
+			"trigger": "group_has_transient_sheet",
+			"details": "Group has a transient sheet",
 			"kind": ["variable", "k", "key"],
 		},
 		{
@@ -43,28 +43,23 @@
 			"kind": ["variable", "k", "key"],
 		},
 		{
+			"trigger": "has_snippet",
+			"details": "Word before cursor expands to a snippet",
+			"kind": ["variable", "k", "key"],
+		},
+		{
+			"trigger": "indented_block",
+			// "details": "TODO",
+			"kind": ["variable", "k", "key"],
+		},
+		{
+			"trigger": "is_javadoc",
+			"details": "Caret in <code>/**</code> block comment",
+			"kind": ["variable", "k", "key"],
+		},
+		{
 			"trigger": "is_recording_macro",
-			"details": "If a macro is currently being recorded",
-			"kind": ["variable", "k", "key"],
-		},
-		{
-			"trigger": "panel_visible",
-			"details": "Panel visibility",
-			"kind": ["variable", "k", "key"],
-		},
-		{
-			"trigger": "overlay_visible",
-			"details": "Overlay visibility",
-			"kind": ["variable", "k", "key"],
-		},
-		{
-			"trigger": "setting.",
-			"details": "View setting value",
-			"kind": ["variable", "k", "key"],
-		},
-		{
-			"trigger": "popup_visible",
-			"details": "Popup visibility",
+			"details": "A macro is currently being recorded",
 			"kind": ["variable", "k", "key"],
 		},
 		{
@@ -78,13 +73,23 @@
 			"kind": ["variable", "k", "key"],
 		},
 		{
-			"trigger": "text",
-			"details": "Selection text",
+			"trigger": "num_selections",
+			"details": "Number of selections in current buffer",
 			"kind": ["variable", "k", "key"],
 		},
 		{
-			"trigger": "indented_block",
-			// "details": "TODO",
+			"trigger": "overlay_has_focus",
+			"details": "Overlay has focus",
+			"kind": ["variable", "k", "key"],
+		},
+		{
+			"trigger": "overlay_name",
+			"details": "Name of the overlay open",
+			"kind": ["variable", "k", "key"],
+		},
+		{
+			"trigger": "overlay_visible",
+			"details": "Overlay visibility",
 			"kind": ["variable", "k", "key"],
 		},
 		{
@@ -103,8 +108,28 @@
 			"kind": ["variable", "k", "key"],
 		},
 		{
+			"trigger": "panel_visible",
+			"details": "Panel visibility",
+			"kind": ["variable", "k", "key"],
+		},
+		{
+			"trigger": "popup_visible",
+			"details": "Popup visibility",
+			"kind": ["variable", "k", "key"],
+		},
+		{
+			"trigger": "preceding_text",
+			"details": "Text prededing the caret",
+			"kind": ["variable", "k", "key"],
+		},
+		{
 			"trigger": "read_only",
 			"details": "If the buffer is marked read only",
+			"kind": ["variable", "k", "key"],
+		},
+		{
+			"trigger": "selection_empty",
+			"details": "Selection is empty",
 			"kind": ["variable", "k", "key"],
 		},
 		{
@@ -113,40 +138,14 @@
 			"kind": ["variable", "k", "key"],
 		},
 		{
-			"trigger": "eol_selector",
-			"details": "Match the scope at the end of the line",
+			"trigger": "setting.",
+			"details": "View setting value",
 			"kind": ["variable", "k", "key"],
 		},
 		{
-			"trigger": "overlay_has_focus",
-			"details": "Overlay has focus",
+			"trigger": "text",
+			"details": "Selection text",
 			"kind": ["variable", "k", "key"],
 		},
-		{
-			"trigger": "overlay_name",
-			"details": "Name of the overlay open",
-			"kind": ["variable", "k", "key"],
-		},
-		{
-			"trigger": "group_has_multiselect",
-			"details": "Group has multiselected tabs",
-			"kind": ["variable", "k", "key"],
-		},
-		{
-			"trigger": "group_has_transient_sheet",
-			"details": "Group has a transient sheet",
-			"kind": ["variable", "k", "key"],
-		},
-		{
-			"trigger": "has_snippet",
-			"details": "Word before cursor expands to a snippet",
-			"kind": ["variable", "k", "key"],
-		},
-		{
-			"trigger": "is_javadoc",
-			"details": "Caret in <code>/**</code> block comment",
-			"kind": ["variable", "k", "key"],
-		},
-
 	]
 }

--- a/Package/Sublime Text Keymap/Sublime Text Keymap.sublime-syntax
+++ b/Package/Sublime Text Keymap/Sublime Text Keymap.sublime-syntax
@@ -424,13 +424,36 @@ contexts:
         3: punctuation.definition.string.end.json
       set: [context-entry-contents-selector, in-mapping-expect-comma]
     - match: |-
-        (?x)(")((?:preceding_|following_)?text|num_selections|selection_empty
-                |has_(?:next|prev)_field
-                |(?:panel|auto_complete|popup)_visible|panel|panel_has_focus
-                |last_command|indented_block|has_snippet|is_javadoc
-                |overlay_(?:has_focus|visible|name)
-                |group_has_(?:multiselect|transient_sheet)
-               )(")
+        (?x)
+        (")
+        ( auto_complete_primed
+        | auto_complete_visible
+        | following_text
+        | group_has_multiselect
+        | group_has_transient_sheet
+        | has_prev_field
+        | has_next_field
+        | has_snippet
+        | indented_block
+        | is_javadoc
+        | is_recording_macro
+        | last_command
+        | last_modifying_command
+        | num_selections
+        | overlay_has_focus
+        | overlay_name
+        | overlay_visible
+        | panel
+        | panel_has_focus
+        | panel_type
+        | panel_visible
+        | popup_visible
+        | preceding_text
+        | read_only
+        | selection_empty
+        | text
+        )
+        (")
       scope: meta.context.key-value.key.other.sublime-keymap string.quoted.double.json
       captures:
         1: punctuation.definition.string.begin.json


### PR DESCRIPTION
This PR...

1. adds `auto_complete_primed`, `is_recording_macro`, `last_modifying_command`, `panel_type` and `read_only`.
2. sorts items alphabetically.